### PR TITLE
Fix AutocompleteInput does not filter references

### DIFF
--- a/src/components/admin/autocomplete-input.tsx
+++ b/src/components/admin/autocomplete-input.tsx
@@ -126,6 +126,7 @@ export const AutocompleteInput = (
                         !isRequired
                       ) {
                         field.onChange("");
+                        setFilters(filterToQuery(""));
                         setOpen(false);
                         return;
                       }


### PR DESCRIPTION
## Problem

When used in a `ReferenceInput`, `AutocompleteInput` only filters the already loaded choices but does not trigger a `getList` call

Fixes #5

## How to test

- `make run`
- http://localhost:5173/#/orders
- Filter for a customer not already present in the `AutocompleteInput` list