### PR TITLE
Fix create button custom label not applied

### DIFF
--- a/src/components/admin/create-button.tsx
+++ b/src/components/admin/create-button.tsx
@@ -26,7 +26,9 @@ export const CreateButton = ({
       onClick={stopPropagation}
     >
       <Plus />
-      <Translate i18nKey={label ?? "ra.action.create"}>Create</Translate>
+      <Translate i18nKey={label ?? "ra.action.create"}>
+        {label ?? "Create"}
+      </Translate>
     </Link>
   );
 };


### PR DESCRIPTION
## Problem

The create button was not applying its custom label.

## Solution

Apply the custom label as the default translation if it's not a translation key.