### PR TITLE
Fix filter remove button position

### DIFF
--- a/src/components/admin/filter-form.tsx
+++ b/src/components/admin/filter-form.tsx
@@ -147,7 +147,7 @@ export const FilterFormInput = (inProps: FilterFormInputProps) => {
           type="button"
           variant="ghost"
           size="sm"
-          className="hide-filter h-9 w-9 cursor-pointer"
+          className="hide-filter h-9 w-9 cursor-pointer mt-auto"
           onClick={handleHide}
           data-key={filterElement.props.source}
           title={translate("ra.action.remove_filter")}


### PR DESCRIPTION
## Problem

The button to remove a filter is centered, it's better to have it aligned with the input.

## Solution

The button to remove the filter is now pushed to the bottom of the item, like the input.