### PR TITLE
Fix some inputs only accept string labels

### DIFF
--- a/src/components/admin/boolean-input.tsx
+++ b/src/components/admin/boolean-input.tsx
@@ -76,7 +76,7 @@ export interface BooleanInputProps {
   defaultValue?: boolean;
   format?: (value: any) => any;
   helperText?: React.ReactNode;
-  label?: string;
+  label?: React.ReactNode;
   onBlur?: (event: React.FocusEvent<HTMLButtonElement>) => void;
   onChange?: (value: any) => void;
   onFocus?: (event: React.FocusEvent<HTMLButtonElement>) => void;

--- a/src/components/admin/reference-array-input.tsx
+++ b/src/components/admin/reference-array-input.tsx
@@ -103,5 +103,4 @@ export interface ReferenceArrayInputProps
   extends InputProps,
     UseReferenceArrayInputParams {
   children?: ReactElement;
-  label?: string;
 }


### PR DESCRIPTION
## Problem

Some inputs only accept string labels instead of `ReactNode`, limiting customization.

## Solution

Fix their types