### PR TITLE
Fix `<ToggleFilterButton>` design

### DIFF
--- a/src/components/admin/toggle-filter-button.tsx
+++ b/src/components/admin/toggle-filter-button.tsx
@@ -28,7 +28,7 @@ export const ToggleFilterButton = ({
       onClick={handleClick}
       className={cn(
         "cursor-pointer",
-        "flex flex-row items-center gap-2 px-2.5",
+        "flex flex-row items-center justify-between gap-2 px-2.5 w-full",
         className,
       )}
       size={size}


### PR DESCRIPTION
## Problem

`<ToggleFilterButton>` does take up the available space which make it harder to click on it.

## Solution

Add some CSS classes to make it nicer

## Screenshot

Before:
<img width="247" height="403" alt="image" src="https://github.com/user-attachments/assets/a12253cd-8215-4708-b9a0-a97d11eb0b8c" />

After:
<img width="247" height="403" alt="image" src="https://github.com/user-attachments/assets/61c2a781-4544-409f-9ef6-7ac6efd12c2a" />
