### PR TITLE
Fix search-input width and usage with long placeholder

### DIFF
--- a/src/components/admin/search-input.tsx
+++ b/src/components/admin/search-input.tsx
@@ -1,9 +1,10 @@
 import { useTranslate } from "ra-core";
 import { Search } from "lucide-react";
 import { TextInput, type TextInputProps } from "@/components/admin/text-input";
+import { cn } from "@/lib/utils";
 
 export const SearchInput = (inProps: SearchInputProps) => {
-  const { label, ...rest } = inProps;
+  const { label, className, ...rest } = inProps;
 
   const translate = useTranslate();
 
@@ -14,11 +15,13 @@ export const SearchInput = (inProps: SearchInputProps) => {
   }
 
   return (
-    <div className="flex flex-grow relative mt-auto w-fit">
+    <div className="flex flex-grow relative mt-auto">
       <TextInput
         label={false}
         helperText={false}
         placeholder={translate("ra.action.search")}
+        className={cn("flex-grow", className)}
+        inputClassName="pr-8"
         {...rest}
       />
       <Search className="absolute right-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />

--- a/src/components/admin/text-input.tsx
+++ b/src/components/admin/text-input.tsx
@@ -16,6 +16,7 @@ import { InputHelperText } from "@/components/admin/input-helper-text";
 
 export type TextInputProps = InputProps & {
   multiline?: boolean;
+  inputClassName?: string;
 } & React.ComponentProps<"textarea"> &
   React.ComponentProps<"input">;
 
@@ -26,6 +27,7 @@ export const TextInput = (props: TextInputProps) => {
     source,
     multiline,
     className,
+    inputClassName,
     validate: _validateProp,
     format: _formatProp,
     ...rest
@@ -46,9 +48,9 @@ export const TextInput = (props: TextInputProps) => {
       )}
       <FormControl>
         {multiline ? (
-          <Textarea {...rest} {...field} />
+          <Textarea {...rest} {...field} className={inputClassName} />
         ) : (
-          <Input {...rest} {...field} />
+          <Input {...rest} {...field} className={inputClassName} />
         )}
       </FormControl>
       <InputHelperText helperText={props.helperText} />

--- a/src/stories/search-input.stories.tsx
+++ b/src/stories/search-input.stories.tsx
@@ -58,3 +58,16 @@ export const Basic = () => (
     <FormValues />
   </Wrapper>
 );
+
+export const LongPlaceholder = () => (
+  <Wrapper>
+    <div className="w-50">
+      <SearchInput
+        source="q"
+        alwaysOn
+        placeholder="Search name, email, company, id..."
+      />
+    </div>
+    <FormValues />
+  </Wrapper>
+);

--- a/src/stories/text-input.stories.tsx
+++ b/src/stories/text-input.stories.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { CoreAdminContext, Form, RecordContextProvider } from "ra-core";
+import { i18nProvider } from "@/lib/i18nProvider.ts";
+import { TextInput, ThemeProvider } from "@/components/admin";
+import { useWatch } from "react-hook-form";
+
+export default {
+  title: "Inputs/TextInput",
+};
+
+const record = {
+  id: 1,
+  title: "Apple",
+};
+
+const FormValues = () => {
+  const values = useWatch();
+  return <pre>{JSON.stringify(values, null, 2)}</pre>;
+};
+
+const Wrapper = ({ children }: React.PropsWithChildren) => (
+  <ThemeProvider>
+    <CoreAdminContext i18nProvider={i18nProvider}>
+      <RecordContextProvider value={record}>
+        <Form>{children}</Form>
+      </RecordContextProvider>
+    </CoreAdminContext>
+  </ThemeProvider>
+);
+
+export const Basic = () => (
+  <Wrapper>
+    <TextInput source="title" />
+    <FormValues />
+  </Wrapper>
+);
+
+export const Disabled = () => (
+  <Wrapper>
+    <TextInput source="title" disabled />
+    <FormValues />
+  </Wrapper>
+);


### PR DESCRIPTION
## Problems

- Search input is not fullWidth by default, contrary to other inputs
- Search input with a long placeholder (or a long value) will render the placeholder/value under the search icon

## Solution

- Make search input fullWidth by default
- Allow to pass `inputClassname` to `TextInput`
- Adjust the `inputClassname` to add some padding for the icon

## How to test

- Added a story for search-input with long placeholder
- We can use the FilterButton story to test the search-input behavior in case of usage within a filter button

## Screenshots

Before

<img width="245" height="47" alt="Screenshot_20251007_094503" src="https://github.com/user-attachments/assets/b3f87df3-59cc-4058-aad0-e5db0d6e4dbf" />


After

<img width="261" height="44" alt="Screenshot_20251007_094625" src="https://github.com/user-attachments/assets/91f2cfcb-83b5-47f1-adc9-28a7e474ec76" />
