### PR TITLE
Doc(MCP): Add documentation about how to configure Context7 for Shadcn Admin Kit

### DIFF
--- a/docs/src/content/docs/MCP.md
+++ b/docs/src/content/docs/MCP.md
@@ -2,9 +2,16 @@
 title: MCP Server
 ---
 
+Shadcn Admin Kit integrates seamlessly with AI agents through the Model Context Protocol (MCP). This integration enables your AI assistant to understand the Shadcn Admin Kit component library and generate admin interfaces more effectively. Two MCP servers can be used to provide the documentation to your AI agent:
+
+- [`shadcn mcp`](#using-shadcn-mcp)
+- [Context7](#using-context7)
+
+## Using Shadcn MCP
+
 This project is compatible with the new `shadcn mcp` command, and contains Cursor rules to instruct the LLM how to setup the `<Admin>` component, the Data Provider, and the resources.
 
-## Prerequisites
+### Prerequisites
 
 It is recommended to use this registry within a **Vite** project that already has **Tailwind CSS v4** configured.
 
@@ -36,7 +43,7 @@ Initialize ShadCN:
 npx shadcn@latest init
 ```
 
-## Setup the registry MCP
+### Setup the registry MCP
 
 Follow the [Shadcn instructions](https://ui.shadcn.com/docs/mcp#quick-start) to create a new MCP server named `shadcn` that uses the `shadcn@latest mcp` command to fetch components:
 
@@ -46,7 +53,7 @@ npx shadcn@latest mcp init --client cursor
 npx shadcn@latest mcp init --client vscode
 ```
 
-### Update shadcn
+#### Update shadcn
 
 Then, update your `components.json` file by adding the shadcn-admin-kit registry:
 
@@ -56,7 +63,7 @@ Then, update your `components.json` file by adding the shadcn-admin-kit registry
 }
 ```
 
-## Start prompting
+### Start prompting
 
 You can now start prompting the LLM to create or edit the `<Admin>` component, the Data Provider, and the resources.
 
@@ -69,7 +76,7 @@ Some examples of prompts you can use:
 
 ## Using Context7
 
-The Shadcn Admin Kit documentation is also available through the [Context7 MCP Server](https://context7.com/marmelab/shadcn-admin-kit). This allow AI Agents to browse the  Shadcn Admin Kit documentation when performing their tasks. Follow the instructions below to configure Context7 for your AI agent.
+The Shadcn Admin Kit documentation is also available through the [Context7 MCP Server](https://context7.com/marmelab/shadcn-admin-kit). This allow AI Agents to browse the Shadcn Admin Kit documentation when performing their tasks. Follow the instructions below to configure Context7 for your AI agent.
 
 ### Using Context7 with GitHub Copilot Agent in VSCode
 

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -7,6 +7,7 @@
 :root {
   --sl-text-h2: 1.5rem;
   --sl-text-h3: 1.25rem;
+  --sl-text-h4: 1.125rem;
 }
 
 img.icon {
@@ -43,14 +44,14 @@ img.icon {
    Improve props table layout
 */
 .sl-markdown-content table {
-    font-size: 0.9rem;
+  font-size: 0.9rem;
 }
 .sl-markdown-content table code {
-    font-size: 0.8rem;
+  font-size: 0.8rem;
 }
 .sl-markdown-content table tr td:has(code) {
-    max-width: 140px;
+  max-width: 140px;
 }
 .sl-markdown-content table tr td code {
-    overflow-wrap: break-word;
+  overflow-wrap: break-word;
 }


### PR DESCRIPTION
<img width="1905" height="3770" alt="localhost_4321_shadcn-admin-kit_docs_mcp_" src="https://github.com/user-attachments/assets/cc7334c9-78d0-4c03-9b0e-41c072722864" />
