### PR TITLE
Fix `<DateInput>` icon placement

### DIFF
--- a/src/components/admin/date-input.tsx
+++ b/src/components/admin/date-input.tsx
@@ -223,7 +223,7 @@ export const DateInput = (props: DateInputProps) => {
           className={cn(
             "ra-input",
             `ra-input-${source}`,
-            "[color-scheme:light] dark:[color-scheme:dark] relative [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:absolute [&::-webkit-calendar-picker-indicator]:right-3 [&::-webkit-calendar-picker-indicator]:opacity-100 pr-10",
+            "[color-scheme:light] dark:[color-scheme:dark] relative [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:absolute [&::-webkit-calendar-picker-indicator]:right-3 [&::-webkit-calendar-picker-indicator]:opacity-100",
             inputClassName,
           )}
           disabled={disabled || readOnly}


### PR DESCRIPTION
## Problem

On Firefox, there's a padding to the right:

<img width="1058" height="146" alt="image" src="https://github.com/user-attachments/assets/4e666df4-b3e8-4fe0-93ce-1e01ca1f5bf5" />

## Solution

We actually don't need the padding at all as we don't render an icon explicitly. It's only the default icon from the browser input.

_Chrome_:
<img width="637" height="255" alt="image" src="https://github.com/user-attachments/assets/d30c07e4-1a0c-4168-a0f2-b235fb90ce7b" />

_Firefox_:
<img width="637" height="255" alt="image" src="https://github.com/user-attachments/assets/e52d498f-863d-4553-b217-4f34c35cf1d8" />
