### PR TITLE
Fix `<SimpleFormIterator>` compatibility with RA 5.13

### DIFF
--- a/src/components/admin/simple-form-iterator.tsx
+++ b/src/components/admin/simple-form-iterator.tsx
@@ -161,6 +161,7 @@ export const SimpleFormIterator = (props: SimpleFormIteratorProps) => {
       total: fields.length,
       add: addField,
       remove: removeField,
+      clear: handleArrayClear,
       reOrder: handleReorder,
       source: finalSource,
     }),


### PR DESCRIPTION
## Problem

RA 5.13 introduced a new required method to the `SimpleFormIteratorContext`. As shadcn-admin-kit does not use the `<SimpleFormIteratorBase>` component yet, projects using 5.13 fail to build.

## Solution

Add the missing method until we refactor to use `<SimpleFormIteratorBase>`