### PR TITLE
Fix rows per page select width to fit content in ListPagination

### DIFF
--- a/src/components/admin/list-pagination.tsx
+++ b/src/components/admin/list-pagination.tsx
@@ -120,7 +120,7 @@ export const ListPagination = ({
             setPerPage(Number(value));
           }}
         >
-          <SelectTrigger className="h-8 w-[70px]">
+          <SelectTrigger className="h-8 w-fit">
             <SelectValue placeholder={perPage} />
           </SelectTrigger>
           <SelectContent side="top">


### PR DESCRIPTION
This PR updates the “rows per page” select control in the `ListPagination` component to size itself to its content instead of using a hard-coded width of 70 px.

The current fixed width causes values longer than two characters to overflow.

<img width="1146" height="89" alt="image" src="https://github.com/user-attachments/assets/dfbb01dd-ce57-4a68-8b0c-83005dc62d18" />





