### PR TITLE
Fix `AutocompleteInput` options cannot be scrolled when used inside a modal

### DIFF
--- a/docs/src/content/docs/AutocompleteInput.md
+++ b/docs/src/content/docs/AutocompleteInput.md
@@ -68,6 +68,7 @@ If you need to let users select more than one item in the list, check out the [`
 | `isPending` | Optional | `boolean` | `false` | If `true`, the component will display a loading indicator. |
 | `label` | Optional | `string` &#124; `ReactNode` | `-` | The label to display for the input |
 | `matchSuggestion` | Optional | `Function` | `-` | Required if `optionText` is a React element. Function returning a boolean indicating whether a choice matches the filter. `(filter, choice) => boolean` |
+| `modal` | Optional | `boolean` | `false` | If `true`, the popover will be displayed as a modal |
 | `offline` | Optional | `ReactNode` | - | What to render when there is no network connectivity when fetching the choices |
 | `onChange` | Optional | `Function` | `-` | A function called with the new value, along with the selected record, when the input value changes |
 | `onCreate` | Optional | `Function` | `-` | A function called with the current filter value when users choose to create a new choice. |
@@ -156,6 +157,36 @@ const filterToQuery = searchText => ({ name_ilike: `%${searchText}%` });
 <ReferenceInput label="Author" source="author_id" reference="authors">
     <AutocompleteInput filterToQuery={filterToQuery} />
 </ReferenceInput>
+```
+
+## Using Inside Another Modal
+
+When used inside another modal (e.g. a `<Dialog>`), the popover containing the suggestions may struggle with some pointer events like scrolling. To fix this, set the `modal` prop to `true` to render the popover as a modal.
+
+```tsx
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { AutocompleteInput, Form } from '@/components/admin';
+
+const MyDialog = () => (
+    <Dialog open>
+        <DialogContent>
+            <DialogHeader>
+                <DialogTitle>My dialog</DialogTitle>
+            </DialogHeader>
+            <Form>
+                <AutocompleteInput
+                    source="category"
+                    choices={[
+                        { id: 'tech', name: 'Tech' },
+                        { id: 'lifestyle', name: 'Lifestyle' },
+                        { id: 'people', name: 'People' },
+                    ]}
+                    modal
+                />
+            </Form>
+        </DialogContent>
+    </Dialog>
+);
 ```
 
 ## Using A Custom Element For Options

--- a/src/components/admin/autocomplete-input.tsx
+++ b/src/components/admin/autocomplete-input.tsx
@@ -215,7 +215,7 @@ export const AutocompleteInput = (
           </FormLabel>
         )}
         <FormControl>
-          <Popover open={open} onOpenChange={handleOpenChange}>
+          <Popover open={open} onOpenChange={handleOpenChange} modal>
             <PopoverTrigger asChild>
               <Button
                 variant="outline"

--- a/src/components/admin/autocomplete-input.tsx
+++ b/src/components/admin/autocomplete-input.tsx
@@ -39,6 +39,7 @@ import {
   useSupportCreateSuggestion,
 } from "ra-core";
 import { InputHelperText } from "./input-helper-text";
+import { PopoverProps } from "@radix-ui/react-popover";
 
 /**
  * Form control that lets users choose a value from a list using a dropdown with autocompletion.
@@ -87,7 +88,7 @@ export const AutocompleteInput = (
       inputText?:
         | React.ReactNode
         | ((option: any | undefined) => React.ReactNode);
-    },
+    } & Pick<PopoverProps, "modal">,
 ) => {
   const {
     filterToQuery = DefaultFilterToQuery,
@@ -99,6 +100,7 @@ export const AutocompleteInput = (
     createItemLabel,
     onCreate,
     optionText,
+    modal,
   } = props;
   const {
     allChoices = [],
@@ -215,7 +217,7 @@ export const AutocompleteInput = (
           </FormLabel>
         )}
         <FormControl>
-          <Popover open={open} onOpenChange={handleOpenChange} modal>
+          <Popover open={open} onOpenChange={handleOpenChange} modal={modal}>
             <PopoverTrigger asChild>
               <Button
                 variant="outline"

--- a/src/stories/autocomplete-input.stories.tsx
+++ b/src/stories/autocomplete-input.stories.tsx
@@ -76,6 +76,60 @@ const contacts = [
     avatar:
       "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=40&h=40&fit=crop&crop=face",
   },
+  {
+    id: 5,
+    first_name: "David",
+    last_name: "Brown",
+    title: "Software Engineer",
+    company_name: "StartupXYZ",
+    avatar:
+      "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=40&h=40&fit=crop&crop=face",
+  },
+  {
+    id: 6,
+    first_name: "Emily",
+    last_name: "Davis",
+    title: "UX Researcher",
+    company_name: "Design Labs",
+    avatar:
+      "https://images.unsplash.com/photo-1494790108755-2616b612b786?w=40&h=40&fit=crop&crop=face",
+  },
+  {
+    id: 7,
+    first_name: "Alex",
+    last_name: "Garcia",
+    title: "Data Scientist",
+    company_name: "AI Solutions",
+    avatar:
+      "https://images.unsplash.com/photo-1539571696257-f0389e7e00f7?w=40&h=40&fit=crop&crop=face",
+  },
+  {
+    id: 8,
+    first_name: "Lisa",
+    last_name: "Rodriguez",
+    title: "Sales Manager",
+    company_name: "Global Enterprises",
+    avatar:
+      "https://images.unsplash.com/photo-1517841905240-472988babdf9?w=40&h=40&fit=crop&crop=face",
+  },
+  {
+    id: 9,
+    first_name: "Tom",
+    last_name: "Anderson",
+    title: "DevOps Engineer",
+    company_name: null,
+    avatar:
+      "https://images.unsplash.com/photo-1519345182560-3f2917c472ef?w=40&h=40&fit=crop&crop=face",
+  },
+  {
+    id: 10,
+    first_name: "Rachel",
+    last_name: "Martinez",
+    title: "Business Analyst",
+    company_name: "Consulting Plus",
+    avatar:
+      "https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=40&h=40&fit=crop&crop=face",
+  },
 ];
 
 const Wrapper = ({ children }: React.PropsWithChildren) => (
@@ -188,3 +242,33 @@ export const OptionText = () => (
     />
   </Wrapper>
 );
+
+export const InsideModal = () => {
+  return (
+    <ThemeProvider>
+      <CoreAdminContext i18nProvider={i18nProvider}>
+        <RecordContextProvider value={record}>
+          <div>
+            <Dialog open>
+              <DialogContent className="sm:max-w-[425px]">
+                <DialogHeader>
+                  <DialogTitle>Select a Contact</DialogTitle>
+                </DialogHeader>
+                <div className="py-4">
+                  <Form>
+                    <AutocompleteInput
+                      source="contact_id"
+                      choices={contacts}
+                      optionText={<ContactOptionRender />}
+                      label="Contact"
+                    />
+                  </Form>
+                </div>
+              </DialogContent>
+            </Dialog>
+          </div>
+        </RecordContextProvider>
+      </CoreAdminContext>
+    </ThemeProvider>
+  );
+};

--- a/src/stories/autocomplete-input.stories.tsx
+++ b/src/stories/autocomplete-input.stories.tsx
@@ -261,6 +261,7 @@ export const InsideModal = () => {
                       choices={contacts}
                       optionText={<ContactOptionRender />}
                       label="Contact"
+                      modal
                     />
                   </Form>
                 </div>


### PR DESCRIPTION
## Problem

`AutocompleteInput` options cannot be scrolled when used inside a modal

## Solution

Apply this fix: https://github.com/shadcn-ui/ui/discussions/4175#discussioncomment-11121245

## How To Test

Use story http://localhost:6006/?path=/story/inputs-autocompleteinput--inside-modal

## Additional Checks

~~- [ ] The PR includes **unit tests** (if not possible, describe why)~~
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/shadcn-admin-kit#contributing).
