### PR TITLE
Add `<TabbedForm>`

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -150,6 +150,7 @@ export default defineConfig({
             "selectinput",
             "showbutton",
             "simpleform",
+            "tabbedform",
             "textarrayinput",
             "textinput",
           ],

--- a/docs/src/content/docs/TabbedForm.md
+++ b/docs/src/content/docs/TabbedForm.md
@@ -1,0 +1,196 @@
+---
+title: "TabbedForm"
+---
+
+`<TabbedForm>` creates a `<form>` to edit a record with inputs organized into tabs, and a toolbar at the bottom (Cancel + Save buttons). It renders all tab panels simultaneously (hidden via CSS when inactive) so form validation runs across every tab, not just the visible one.
+
+## Usage
+
+`<TabbedForm>` is often used as child of [`<Create>`](./Create.md) or [`<Edit>`](./Edit.md). Use `<TabbedForm.Tab>` components to define each tab.
+
+```tsx
+import { Edit, TabbedForm, TextInput } from "@/components/admin";
+
+export const PostEdit = () => (
+  <Edit>
+    <TabbedForm>
+      <TabbedForm.Tab label="Summary">
+        <TextInput source="title" />
+        <TextInput source="body" multiline />
+      </TabbedForm.Tab>
+      <TabbedForm.Tab label="Details">
+        <TextInput source="author" />
+        <TextInput source="views" type="number" />
+      </TabbedForm.Tab>
+    </TabbedForm>
+  </Edit>
+);
+```
+
+By default the active tab is synced with the URL (e.g. `/posts/1/edit` shows the first tab, `/posts/1/edit/1` shows the second). Set `syncWithLocation={false}` to use local state instead.
+
+## Props
+
+| Prop                     | Required | Type                 | Default           | Description                                            |
+| ------------------------ | -------- | -------------------- | ----------------- | ------------------------------------------------------ |
+| `children`               | Required | `ReactNode`          | -                 | `<TabbedForm.Tab>` elements                            |
+| `className`              | Optional | `string`             | -                 | Extra class applied to the `<form>` element            |
+| `defaultValues`          | Optional | `object \| function` | -                 | Default values for the form                            |
+| `noValidate`             | Optional | `boolean`            | -                 | Disable browser-native validation                      |
+| `onSubmit`               | Optional | `function`           | `save`            | Callback when the form is submitted                    |
+| `sanitizeEmptyValues`    | Optional | `boolean`            | -                 | Remove empty values from the form state                |
+| `syncWithLocation`       | Optional | `boolean`            | `true`            | Sync the active tab with the URL                       |
+| `tabs`                   | Optional | `ReactElement`       | -                 | Override the tab header component                      |
+| `toolbar`                | Optional | `ReactNode \| false` | `<FormToolbar />` | Toolbar rendered below the tabs. Pass `false` to hide. |
+| `validate`               | Optional | `function`           | -                 | Form-level validation function                         |
+| `warnWhenUnsavedChanges` | Optional | `boolean`            | -                 | Warn the user before leaving with unsaved changes      |
+
+## `<TabbedForm.Tab>` Props
+
+| Prop               | Required | Type                     | Default | Description                                                                                   |
+| ------------------ | -------- | ------------------------ | ------- | --------------------------------------------------------------------------------------------- |
+| `label`            | Required | `string \| ReactElement` | -       | Tab header label (also used as a translation key)                                             |
+| `children`         | Optional | `ReactNode`              | -       | Inputs displayed when this tab is active                                                      |
+| `className`        | Optional | `string`                 | -       | Class applied to the content panel (and the tab trigger when used without `contentClassName`) |
+| `contentClassName` | Optional | `string`                 | -       | Class applied exclusively to the content panel                                                |
+| `count`            | Optional | `ReactNode`              | -       | Badge rendered next to the label (e.g. record count)                                          |
+| `icon`             | Optional | `ReactElement`           | -       | Icon rendered before the label                                                                |
+| `path`             | Optional | `string`                 | -       | Custom URL segment for this tab (defaults to the tab index)                                   |
+
+## Validation
+
+All tab panels are always mounted. Invalid inputs on inactive tabs still contribute to the form's validation state, and the corresponding tab header turns red to alert the user.
+
+```tsx
+import { Edit, TabbedForm, TextInput } from "@/components/admin";
+import { required, minLength } from "ra-core";
+
+export const PostEdit = () => (
+  <Edit>
+    <TabbedForm>
+      <TabbedForm.Tab label="Summary">
+        <TextInput source="title" validate={required()} />
+      </TabbedForm.Tab>
+      <TabbedForm.Tab label="Details">
+        <TextInput source="author" validate={[required(), minLength(3)]} />
+      </TabbedForm.Tab>
+    </TabbedForm>
+  </Edit>
+);
+```
+
+When the user clicks Save and the `author` field is empty, the **Details** tab header turns red even though it is not the active tab.
+
+## URL Sync (`syncWithLocation`)
+
+By default (`syncWithLocation={true}`) the active tab is reflected in the URL:
+
+- First tab → `/posts/1/edit`
+- Second tab → `/posts/1/edit/1`
+- Third tab → `/posts/1/edit/2`
+
+This means users can bookmark or share a deep-link directly to a specific tab, and the browser Back button works as expected.
+
+Set `syncWithLocation={false}` to manage tab state locally (useful inside modals or when you have nested routers):
+
+```tsx
+<TabbedForm syncWithLocation={false}>
+  <TabbedForm.Tab label="Summary">...</TabbedForm.Tab>
+  <TabbedForm.Tab label="Details">...</TabbedForm.Tab>
+</TabbedForm>
+```
+
+## Custom Tab Paths
+
+Use the `path` prop on a tab to override the URL segment:
+
+```tsx
+<TabbedForm>
+  <TabbedForm.Tab label="Summary" path="">
+    <TextInput source="title" />
+  </TabbedForm.Tab>
+  <TabbedForm.Tab label="Details" path="meta">
+    <TextInput source="author" />
+  </TabbedForm.Tab>
+</TabbedForm>
+```
+
+The second tab is now reachable at `/posts/1/edit/meta`.
+
+## Toolbar
+
+The default `<FormToolbar>` renders Cancel + Save buttons. You can customise or replace it:
+
+```tsx
+import { Edit, TabbedForm, FormToolbar, TextInput } from "@/components/admin";
+
+export const PostEdit = () => (
+  <Edit>
+    <TabbedForm
+      toolbar={
+        <FormToolbar className="sticky bottom-0 bg-background/80 backdrop-blur" />
+      }
+    >
+      <TabbedForm.Tab label="Summary">
+        <TextInput source="title" />
+      </TabbedForm.Tab>
+    </TabbedForm>
+  </Edit>
+);
+```
+
+Pass `toolbar={false}` to remove it entirely.
+
+## Styling Tab Content
+
+Use `className` (or `contentClassName`) on a `<TabbedForm.Tab>` to constrain or style the content panel:
+
+```tsx
+<TabbedForm.Tab label="Summary" className="max-w-2xl">
+  <TextInput source="title" />
+</TabbedForm.Tab>
+```
+
+## Default Values
+
+Populate the form from a record or supply defaults with `defaultValues`:
+
+```tsx
+const postDefaults = { status: "draft", views: 0 };
+
+export const PostCreate = () => (
+  <Create>
+    <TabbedForm defaultValues={postDefaults}>
+      <TabbedForm.Tab label="Summary">
+        <TextInput source="title" />
+      </TabbedForm.Tab>
+      <TabbedForm.Tab label="Meta">
+        <TextInput source="status" />
+        <TextInput source="views" type="number" />
+      </TabbedForm.Tab>
+    </TabbedForm>
+  </Create>
+);
+```
+
+## Access Control
+
+Wrap individual inputs with `<CanAccess>` to hide them based on permissions:
+
+```tsx
+import { CanAccess } from "ra-core";
+import { Edit, TabbedForm, TextInput } from "@/components/admin";
+
+export const PostEdit = () => (
+  <Edit>
+    <TabbedForm>
+      <TabbedForm.Tab label="Summary">
+        <TextInput source="title" />
+        <CanAccess action="write" resource="posts.body">
+          <TextInput source="body" multiline />
+        </CanAccess>
+      </TabbedForm.Tab>
+    </TabbedForm>
+  </Edit>
+);
+```

--- a/registry.json
+++ b/registry.json
@@ -34,6 +34,7 @@
         "skeleton",
         "sonner",
         "table",
+        "tabs",
         "textarea",
         "tooltip"
       ],
@@ -330,6 +331,10 @@
         },
         {
           "path": "src/components/admin/sort-button.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "src/components/admin/tabbed-form.tsx",
           "type": "registry:component"
         },
         {

--- a/src/components/admin/boolean-field.tsx
+++ b/src/components/admin/boolean-field.tsx
@@ -1,7 +1,7 @@
 import { Check, type LucideIcon, X } from "lucide-react";
 import { RaRecord, useFieldValue, useTranslate } from "ra-core";
 
-import type { FieldProps } from "@/lib/field.type";
+import type { FieldProps } from "@/lib/field.type.ts";
 import { cn } from "@/lib/utils";
 import {
   Tooltip,

--- a/src/components/admin/index.ts
+++ b/src/components/admin/index.ts
@@ -68,6 +68,7 @@ export * from "./simple-form-iterator";
 export * from "./simple-show-layout";
 export * from "./single-field-list";
 export * from "./sort-button";
+export * from "./tabbed-form";
 export * from "./text-array-input";
 export * from "./text-field";
 export * from "./text-input";

--- a/src/components/admin/tabbed-form.spec.tsx
+++ b/src/components/admin/tabbed-form.spec.tsx
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+
+import {
+  Basic,
+  ThreeTabs,
+  WithValidation,
+  NoToolbar,
+} from "@/stories/tabbed-form.stories";
+
+describe("<TabbedForm />", () => {
+  it("should render tab headers", async () => {
+    const screen = render(<Basic theme="system" />);
+    await expect
+      .element(screen.getByRole("tab", { name: "Summary" }))
+      .toBeInTheDocument();
+    await expect
+      .element(screen.getByRole("tab", { name: "Details" }))
+      .toBeInTheDocument();
+  });
+
+  it("should show the first tab content by default", async () => {
+    const screen = render(<Basic theme="system" />);
+    const titleInput = screen.getByRole("textbox", { name: /title/i });
+    await expect.element(titleInput).toBeVisible();
+  });
+
+  it("should mount all tab content at once (not just the active tab)", async () => {
+    // Both tab panels are rendered in the DOM even when not active,
+    // so form validation can run across all tabs.
+    const { container } = render(<Basic theme="system" />);
+    // Second panel (aria-hidden) must be in the DOM with its inputs
+    const secondPanel = container.querySelector("#tabpanel-1");
+    expect(secondPanel).toBeTruthy();
+    expect(secondPanel!.querySelector("input")).toBeTruthy();
+  });
+
+  it("should hide inactive tab content via display:none", async () => {
+    const { container } = render(<Basic theme="system" />);
+    // Second tab panel should be hidden
+    const hiddenPanel = container.querySelector('[aria-hidden="true"]');
+    expect(hiddenPanel).toBeTruthy();
+    expect((hiddenPanel as HTMLElement).style.display).toBe("none");
+  });
+
+  it("should show second tab content when its header is clicked", async () => {
+    const screen = render(<Basic theme="system" />);
+    const detailsTab = screen.getByRole("tab", { name: "Details" });
+    await detailsTab.click();
+    const authorInput = screen.getByRole("textbox", { name: /author/i });
+    await expect.element(authorInput).toBeVisible();
+  });
+
+  it("should hide first tab content after switching to second tab", async () => {
+    const { container, getByRole } = render(<Basic theme="system" />);
+    await getByRole("tab", { name: "Details" }).click();
+    // First panel is still in the DOM but hidden via display:none + aria-hidden
+    const firstPanel = container.querySelector("#tabpanel-0") as HTMLElement;
+    expect(firstPanel).toBeTruthy();
+    expect(firstPanel.style.display).toBe("none");
+    // Its inputs are still mounted (required for cross-tab validation)
+    expect(firstPanel.querySelector("input")).toBeTruthy();
+  });
+
+  it("should render all three tabs", async () => {
+    const screen = render(<ThreeTabs theme="system" />);
+    await expect
+      .element(screen.getByRole("tab", { name: "Summary" }))
+      .toBeInTheDocument();
+    await expect
+      .element(screen.getByRole("tab", { name: "Body" }))
+      .toBeInTheDocument();
+    await expect
+      .element(screen.getByRole("tab", { name: "Details" }))
+      .toBeInTheDocument();
+  });
+
+  it("should navigate between multiple tabs", async () => {
+    const screen = render(<ThreeTabs theme="system" />);
+    await screen.getByRole("tab", { name: "Body" }).click();
+    const bodyInput = screen.getByRole("textbox", { name: /body/i });
+    await expect.element(bodyInput).toBeVisible();
+    await screen.getByRole("tab", { name: "Details" }).click();
+    const authorInput = screen.getByRole("textbox", { name: /author/i });
+    await expect.element(authorInput).toBeVisible();
+  });
+
+  it("should render the default toolbar with save and cancel buttons", async () => {
+    const screen = render(<Basic theme="system" />);
+    await expect
+      .element(screen.getByRole("button", { name: /save/i }))
+      .toBeInTheDocument();
+  });
+
+  it("should not render a toolbar when toolbar={false}", async () => {
+    const screen = render(<NoToolbar theme="system" />);
+    const saveButton = screen.getByRole("button", { name: /save/i });
+    await expect.element(saveButton).not.toBeInTheDocument();
+  });
+
+  it("should show validation errors after attempting to submit with empty required fields", async () => {
+    const { container, getByRole } = render(<WithValidation theme="system" />);
+    await getByRole("button", { name: /save/i }).click();
+    // react-hook-form marks invalid inputs with aria-invalid="true"
+    const invalidInput = container.querySelector('[aria-invalid="true"]');
+    expect(invalidInput).toBeTruthy();
+  });
+
+  it("should associate tab panels with tab headers via aria attributes", async () => {
+    const { container } = render(<Basic theme="system" />);
+    const firstTab = container.querySelector('[role="tab"][id^="tabheader-"]') as HTMLElement;
+    expect(firstTab).toBeTruthy();
+    const value = firstTab.id.replace("tabheader-", "");
+    // The corresponding panel must exist and point back to the tab header
+    const panel = container.querySelector(`#tabpanel-${value}`) as HTMLElement;
+    expect(panel).toBeTruthy();
+    expect(panel.getAttribute("role")).toBe("tabpanel");
+    expect(panel.getAttribute("aria-labelledby")).toBe(`tabheader-${value}`);
+  });
+});

--- a/src/components/admin/tabbed-form.tsx
+++ b/src/components/admin/tabbed-form.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Tabs, TabsList, TabsTrigger } from "../ui/tabs";
 import type { FormProps } from "ra-core";

--- a/src/components/admin/tabbed-form.tsx
+++ b/src/components/admin/tabbed-form.tsx
@@ -1,0 +1,376 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Tabs, TabsList, TabsTrigger } from "../ui/tabs";
+import type { FormProps } from "ra-core";
+import {
+  Form,
+  FormGroupContextProvider,
+  useFormGroup,
+  useTranslate,
+  useParams,
+  useSplatPathBase,
+  useLocation,
+  useMatchPath,
+  useRouterProvider,
+} from "ra-core";
+import type { ReactElement, ReactNode } from "react";
+import { Children, cloneElement, isValidElement, useState } from "react";
+import { useNavigate } from "react-router";
+
+import { FormToolbar } from "./simple-form";
+import { cn } from "@/lib/utils";
+
+/**
+ * Infers the tabbed form root path from the current location.
+ * Mirrors useFormRootPath from ra-ui-materialui.
+ */
+function useFormRootPath() {
+  const location = useLocation();
+  const matchPath = useMatchPath();
+  const createMatch = matchPath(":resource/create/*", location.pathname);
+  const editMatch = matchPath(":resource/:id/*", location.pathname);
+  if (createMatch) return createMatch.pathnameBase;
+  if (editMatch) return editMatch.pathnameBase;
+  return "";
+}
+
+/**
+ * Returns the URL segment for a tab.
+ * First tab = '' (no segment), subsequent tabs = their index as a string,
+ * unless they declare a custom `path` prop.
+ * Mirrors getTabbedFormTabFullPath from ra-ui-materialui.
+ */
+function getTabPath(tab: ReactElement<FormTabProps>, index: number): string {
+  return tab.props.path != null
+    ? tab.props.path
+    : index > 0
+      ? index.toString()
+      : "";
+}
+
+/**
+ * Renders the tab trigger list. Must be inside a Route context when
+ * syncWithLocation is true so that useParams() can read params['*'].
+ */
+function TabbedFormTabsList({
+  tabs,
+  syncWithLocation,
+  tabValue,
+  onValueChange,
+}: {
+  tabs: ReactElement<FormTabProps>[];
+  syncWithLocation: boolean;
+  tabValue: number;
+  onValueChange: (value: string) => void;
+}) {
+  const params = useParams();
+  const currentValue = syncWithLocation
+    ? (params["*"] ?? "")
+    : tabValue.toString();
+
+  return (
+    <Tabs value={currentValue} onValueChange={onValueChange} className="w-full">
+      <TabsList className="mb-4 w-full">
+        {tabs.map((tab, index) => {
+          const tabPath = getTabPath(tab, index);
+          return cloneElement(tab as ReactElement<any>, {
+            key: tabPath !== "" ? tabPath : "tab-0",
+            intent: "header",
+            value: syncWithLocation ? tabPath : index,
+          });
+        })}
+      </TabsList>
+    </Tabs>
+  );
+}
+
+/**
+ * Renders a tab trigger (TabsTrigger) with validation error state.
+ * When the tab's form group has validation errors the trigger turns
+ * destructive so users know which tab needs attention.
+ */
+function FormTabHeader({
+  label,
+  value,
+  icon,
+  className,
+  count,
+}: {
+  label: string | ReactElement;
+  value: string | number;
+  icon?: ReactElement;
+  className?: string;
+  count?: ReactNode;
+}) {
+  const translate = useTranslate();
+  const formGroup = useFormGroup(value.toString());
+
+  let tabLabel: ReactNode =
+    typeof label === "string" ? translate(label, { _: label }) : label;
+  if (count !== undefined) {
+    tabLabel = (
+      <span>
+        {tabLabel} ({count})
+      </span>
+    );
+  }
+
+  return (
+    <TabsTrigger
+      value={value.toString()}
+      className={cn(
+        "form-tab",
+        className,
+        !formGroup.isValid &&
+          "text-destructive data-[state=active]:text-destructive",
+      )}
+      id={`tabheader-${value}`}
+      aria-controls={`tabpanel-${value}`}
+    >
+      {icon && <span className="mr-2">{icon}</span>}
+      {tabLabel}
+    </TabsTrigger>
+  );
+}
+
+/**
+ * A single tab within a TabbedForm.
+ *
+ * Renders in two modes depending on the `intent` prop injected by TabbedForm:
+ * - `intent="header"` → a TabsTrigger showing the label (with error state)
+ * - `intent="content"` → a FormGroupContextProvider + content div, always
+ *   mounted but hidden via CSS when not active so validation runs on all tabs
+ *
+ * @example
+ * <TabbedForm.Tab label="Summary">
+ *   <TextInput source="title" />
+ * </TabbedForm.Tab>
+ */
+export function FormTab(props: FormTabProps) {
+  const {
+    children,
+    className,
+    contentClassName,
+    count,
+    hidden,
+    icon,
+    iconPosition: _iconPosition,
+    intent,
+    label,
+    onChange: _onChange,
+    path: _path,
+    resource: _resource,
+    syncWithLocation: _syncWithLocation,
+    value,
+    ...rest
+  } = props;
+
+  if (typeof value === "undefined") {
+    throw new Error("the value prop is required at runtime");
+  }
+
+  if (intent === "header") {
+    return (
+      <FormTabHeader
+        label={label}
+        count={count}
+        value={value}
+        icon={icon}
+        className={className}
+      />
+    );
+  }
+
+  // content intent — always rendered, hidden via CSS when not active
+  return (
+    <FormGroupContextProvider name={value.toString()}>
+      <div
+        style={hidden ? { display: "none" } : undefined}
+        className={cn("flex flex-col gap-4", contentClassName ?? className)}
+        role="tabpanel"
+        id={`tabpanel-${value}`}
+        aria-labelledby={`tabheader-${value}`}
+        // Set undefined instead of false because WAI-ARIA 1.1 notes that
+        // aria-hidden="false" behaves inconsistently across browsers.
+        aria-hidden={hidden || undefined}
+        {...rest}
+      >
+        {children}
+      </div>
+    </FormGroupContextProvider>
+  );
+}
+
+FormTab.displayName = "FormTab";
+
+const defaultToolbar = <FormToolbar />;
+
+/**
+ * The view layer of TabbedForm. Renders tab headers, all tab panels
+ * (with inactive ones hidden), and the toolbar.
+ */
+function TabbedFormView({
+  children,
+  className,
+  syncWithLocation = true,
+  formRootPathname: _formRootPathname,
+  toolbar = defaultToolbar,
+}: TabbedFormViewProps) {
+  const { Route, Routes } = useRouterProvider();
+  const location = useLocation();
+  const matchPath = useMatchPath();
+  const splatPathBase = useSplatPathBase();
+  const navigate = useNavigate();
+  const [tabValue, setTabValue] = useState(0);
+
+  const tabs = (
+    Children.toArray(children) as ReactElement<FormTabProps>[]
+  ).filter(isValidElement);
+
+  const handleValueChange = (value: string) => {
+    if (syncWithLocation) {
+      const newPathname =
+        value === "" ? splatPathBase : `${splatPathBase}/${value}`;
+      navigate({
+        pathname: newPathname,
+        search: location.search,
+        hash: location.hash,
+      });
+    } else {
+      setTabValue(parseInt(value, 10));
+    }
+  };
+
+  const tabHeadersList = (
+    <TabbedFormTabsList
+      tabs={tabs}
+      syncWithLocation={syncWithLocation}
+      tabValue={tabValue}
+      onValueChange={handleValueChange}
+    />
+  );
+
+  return (
+    <div className={cn("tabbed-form", className)}>
+      {/* Tab header must be inside a Route when syncWithLocation=true so that
+          useParams()['*'] resolves to the active tab path segment. */}
+      {syncWithLocation ? (
+        <Routes>
+          <Route path="/*" element={tabHeadersList} />
+        </Routes>
+      ) : (
+        tabHeadersList
+      )}
+
+      {/* All tabs are rendered (not only the one in focus) to allow validation
+          on tabs not in focus. Hidden tabs use display:none via inline style. */}
+      <div>
+        {tabs.map((tab, index) => {
+          if (!tab) return null;
+          const tabPath = getTabPath(tab, index);
+          const hidden = syncWithLocation
+            ? !matchPath(`${splatPathBase}/${tabPath}`, location.pathname)
+            : tabValue !== index;
+
+          return cloneElement(tab as ReactElement<any>, {
+            key: tabPath !== "" ? tabPath : "tab-0",
+            intent: "content",
+            hidden,
+            value: syncWithLocation ? tabPath : index,
+          });
+        })}
+      </div>
+
+      {toolbar !== false ? toolbar : null}
+    </div>
+  );
+}
+
+/**
+ * A form layout with tabbed navigation using shadcn Tabs.
+ *
+ * Use `TabbedForm.Tab` as child components to define each tab. The `toolbar`
+ * prop renders below the tabs and defaults to a Cancel + Save toolbar.
+ *
+ * Set `syncWithLocation={false}` to use local state instead of URL routing.
+ *
+ * @see {@link https://marmelab.com/react-admin/TabbedForm.html TabbedForm documentation}
+ *
+ * @example
+ * import { TabbedForm } from '@/components/admin';
+ *
+ * const PostEdit = () => (
+ *   <Edit>
+ *     <TabbedForm>
+ *       <TabbedForm.Tab label="Summary">
+ *         <TextInput source="title" />
+ *       </TabbedForm.Tab>
+ *       <TabbedForm.Tab label="Body">
+ *         <TextInput source="body" multiline />
+ *       </TabbedForm.Tab>
+ *     </TabbedForm>
+ *   </Edit>
+ * );
+ */
+export function TabbedForm(props: TabbedFormProps) {
+  const formRootPathname = useFormRootPath();
+  const {
+    children,
+    toolbar = defaultToolbar,
+    syncWithLocation = true,
+    className,
+    tabs: _tabs,
+    ...rest
+  } = props;
+
+  return (
+    <Form
+      formRootPathname={formRootPathname}
+      className={cn("flex w-full flex-col gap-4", className)}
+      {...rest}
+    >
+      <TabbedFormView
+        formRootPathname={formRootPathname}
+        syncWithLocation={syncWithLocation}
+        toolbar={toolbar}
+      >
+        {children}
+      </TabbedFormView>
+    </Form>
+  );
+}
+
+TabbedForm.Tab = FormTab;
+
+export interface FormTabProps {
+  children?: ReactNode;
+  className?: string;
+  contentClassName?: string;
+  count?: ReactNode;
+  hidden?: boolean;
+  icon?: ReactElement;
+  iconPosition?: "top" | "bottom" | "start" | "end";
+  intent?: "header" | "content";
+  label: string | ReactElement;
+  onChange?: (event: any, value: any) => void;
+  path?: string;
+  resource?: string;
+  syncWithLocation?: boolean;
+  value?: string | number;
+  [key: string]: any;
+}
+
+interface TabbedFormViewProps {
+  children?: ReactNode;
+  className?: string;
+  syncWithLocation?: boolean;
+  formRootPathname?: string;
+  toolbar?: ReactNode | false;
+}
+
+export interface TabbedFormProps extends Omit<FormProps, "children"> {
+  children?: ReactNode;
+  toolbar?: ReactNode | false;
+  className?: string;
+  syncWithLocation?: boolean;
+  tabs?: ReactElement;
+}

--- a/src/demo/products/ProductEdit.tsx
+++ b/src/demo/products/ProductEdit.tsx
@@ -5,7 +5,7 @@ import {
   ReferenceField,
   ReferenceInput,
   ReferenceManyField,
-  SimpleForm,
+  TabbedForm,
   TextInput,
 } from "@/components/admin";
 import {
@@ -23,12 +23,14 @@ import { StarRatingField, StarArray } from "../reviews/StarRatingField";
 export const ProductEdit = () => {
   return (
     <Edit>
-      <div className="flex items-start justify-between gap-2 mb-4">
-        <SimpleForm
+      <TabbedForm
+        toolbar={
+          <FormToolbar className="md:pl-36 pt-4 pb-4 sticky bottom-0 bg-linear-to-b from-transparent to-background to-10%" />
+        }
+      >
+        <TabbedForm.Tab
+          label="resources.products.tabs.details"
           className="max-w-2xl"
-          toolbar={
-            <FormToolbar className="md:pl-36 pt-4 pb-4 sticky bottom-0 bg-linear-to-b from-transparent to-background to-10%" />
-          }
         >
           <div className="flex flex-col md:flex-row gap-4 mb-2">
             <h3 className="min-w-32 text-sm font-semibold">
@@ -107,9 +109,11 @@ export const ProductEdit = () => {
               />
             </div>
           </div>
-        </SimpleForm>
-        <ProductReviews />
-      </div>
+        </TabbedForm.Tab>
+        <TabbedForm.Tab label="resources.products.tabs.reviews">
+          <ProductReviews />
+        </TabbedForm.Tab>
+      </TabbedForm>
     </Edit>
   );
 };

--- a/src/stories/tabbed-form.stories.tsx
+++ b/src/stories/tabbed-form.stories.tsx
@@ -1,0 +1,182 @@
+import { type ReactNode } from "react";
+import {
+  CoreAdminContext,
+  RecordContextProvider,
+  required,
+  ResourceContextProvider,
+} from "ra-core";
+import { ThemeProvider } from "@/components/admin/theme-provider";
+import { TabbedForm } from "@/components/admin/tabbed-form";
+import { TextInput } from "@/components/admin/text-input";
+import { FormToolbar } from "@/components/admin/simple-form";
+import { i18nProvider } from "@/lib/i18nProvider";
+
+const defaultRecord = {
+  id: 1,
+  title: "Hello World",
+  body: "Lorem ipsum dolor sit amet.",
+  author: "Jane Doe",
+  views: 42,
+};
+
+const StoryWrapper = ({
+  children,
+  theme,
+  record = defaultRecord,
+}: {
+  children: ReactNode;
+  theme: "system" | "light" | "dark";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  record?: any;
+}) => (
+  <ThemeProvider defaultTheme={theme}>
+    <CoreAdminContext i18nProvider={i18nProvider}>
+      <RecordContextProvider value={record}>{children}</RecordContextProvider>
+    </CoreAdminContext>
+  </ThemeProvider>
+);
+
+const storyArgs = {
+  args: { theme: "system" as const },
+  argTypes: {
+    theme: {
+      type: "select" as const,
+      options: ["light", "dark", "system"],
+    },
+  },
+};
+
+export default {
+  title: "Forms/TabbedForm",
+  parameters: {
+    docs: {
+      codePanel: true,
+    },
+  },
+};
+
+export const Basic = ({ theme }: { theme: "system" | "light" | "dark" }) => (
+  <StoryWrapper theme={theme}>
+    <ResourceContextProvider value="posts">
+      <TabbedForm syncWithLocation={false}>
+        <TabbedForm.Tab label="Summary">
+          <TextInput source="title" />
+          <TextInput source="body" multiline />
+        </TabbedForm.Tab>
+        <TabbedForm.Tab label="Details">
+          <TextInput source="author" />
+          <TextInput source="views" type="number" />
+        </TabbedForm.Tab>
+      </TabbedForm>
+    </ResourceContextProvider>
+  </StoryWrapper>
+);
+Object.assign(Basic, storyArgs);
+
+export const ThreeTabs = ({
+  theme,
+}: {
+  theme: "system" | "light" | "dark";
+}) => (
+  <StoryWrapper theme={theme}>
+    <ResourceContextProvider value="posts">
+      <TabbedForm syncWithLocation={false}>
+        <TabbedForm.Tab label="Summary">
+          <TextInput source="title" />
+        </TabbedForm.Tab>
+        <TabbedForm.Tab label="Body">
+          <TextInput source="body" multiline />
+        </TabbedForm.Tab>
+        <TabbedForm.Tab label="Details">
+          <TextInput source="author" />
+          <TextInput source="views" type="number" />
+        </TabbedForm.Tab>
+      </TabbedForm>
+    </ResourceContextProvider>
+  </StoryWrapper>
+);
+Object.assign(ThreeTabs, storyArgs);
+
+export const WithValidation = ({
+  theme,
+}: {
+  theme: "system" | "light" | "dark";
+}) => (
+  <StoryWrapper theme={theme} record={{ id: 1 }}>
+    <ResourceContextProvider value="posts">
+      <TabbedForm syncWithLocation={false}>
+        <TabbedForm.Tab label="Summary">
+          <TextInput source="title" validate={required()} />
+        </TabbedForm.Tab>
+        <TabbedForm.Tab label="Details">
+          <TextInput source="author" validate={required()} />
+        </TabbedForm.Tab>
+      </TabbedForm>
+    </ResourceContextProvider>
+  </StoryWrapper>
+);
+Object.assign(WithValidation, storyArgs);
+
+export const NoToolbar = ({
+  theme,
+}: {
+  theme: "system" | "light" | "dark";
+}) => (
+  <StoryWrapper theme={theme}>
+    <ResourceContextProvider value="posts">
+      <TabbedForm syncWithLocation={false} toolbar={false}>
+        <TabbedForm.Tab label="Summary">
+          <TextInput source="title" />
+        </TabbedForm.Tab>
+        <TabbedForm.Tab label="Details">
+          <TextInput source="author" />
+        </TabbedForm.Tab>
+      </TabbedForm>
+    </ResourceContextProvider>
+  </StoryWrapper>
+);
+Object.assign(NoToolbar, storyArgs);
+
+export const CustomToolbar = ({
+  theme,
+}: {
+  theme: "system" | "light" | "dark";
+}) => (
+  <StoryWrapper theme={theme}>
+    <ResourceContextProvider value="posts">
+      <TabbedForm
+        syncWithLocation={false}
+        toolbar={<FormToolbar className="justify-start" />}
+      >
+        <TabbedForm.Tab label="Summary">
+          <TextInput source="title" />
+        </TabbedForm.Tab>
+        <TabbedForm.Tab label="Details">
+          <TextInput source="author" />
+        </TabbedForm.Tab>
+      </TabbedForm>
+    </ResourceContextProvider>
+  </StoryWrapper>
+);
+Object.assign(CustomToolbar, storyArgs);
+
+export const WithContentClassName = ({
+  theme,
+}: {
+  theme: "system" | "light" | "dark";
+}) => (
+  <StoryWrapper theme={theme}>
+    <ResourceContextProvider value="posts">
+      <TabbedForm syncWithLocation={false}>
+        <TabbedForm.Tab label="Summary" className="max-w-lg">
+          <TextInput source="title" />
+          <TextInput source="body" multiline />
+        </TabbedForm.Tab>
+        <TabbedForm.Tab label="Details" className="max-w-xs">
+          <TextInput source="author" />
+        </TabbedForm.Tab>
+      </TabbedForm>
+    </ResourceContextProvider>
+  </StoryWrapper>
+);
+Object.assign(WithContentClassName, storyArgs);


### PR DESCRIPTION
## Problem

`<TabbedForm>` component was missing.

## Solution

This adds a `TabbedForm` component that should have full parity with the mui version.

## How To Test

`pnpm run test`

## Additional Checks

- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

I also fixed an issue from my previous PR ( #145 ) when building the registry. Sorry about that!