### PR TITLE
Add router-agnostic Link component wrapping ra-core's LinkBase

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -162,6 +162,7 @@ export default defineConfig({
             "confirm",
             "error",
             "layout",
+            "link",
             "loading",
             "localesmenubutton",
             "loginpage",

--- a/docs/src/content/docs/Breadcrumb.md
+++ b/docs/src/content/docs/Breadcrumb.md
@@ -22,9 +22,8 @@ So for the CRUD pages of a `posts` resource with `recordRepresentation="title"`,
 To customize the breadcrumb for these pages, disable the default breadcrumb by using the `disableBreadcrumb` prop on the page component, then use the `<Breadcrumb>` component as a descendent. For example, to customize the breadcrumb for the Edit page of the `posts` resource:
 
 ```tsx
-import { Edit, Breadcrumb, SimpleForm } from "@/components/admin";
+import { Edit, Breadcrumb, Link, SimpleForm } from "@/components/admin";
 import { RecordRepresentation } from 'ra-core';
-import { Link } from "react-router";
 
 const PostEdit = () => (
     <Edit disableBreadcrumb>
@@ -49,7 +48,7 @@ This example shows that you can use `<Breacrumb.Item>` for intermediate links an
 To add a breadcrumb to a custom page component, simply use the `<Breadcrumb>` component as a descendent of your page component. For example:
 
 ```tsx
-import { Breadcrumb } from "@/components/admin";
+import { Breadcrumb, Link } from "@/components/admin";
 
 const SettingsPage = () => (
     <>

--- a/docs/src/content/docs/Link.md
+++ b/docs/src/content/docs/Link.md
@@ -1,0 +1,97 @@
+---
+title: "Link"
+---
+
+A router-agnostic navigation component that wraps ra-core's `LinkBase`. It provides a routing abstraction layer so that admin components are not directly coupled to a specific router package (like `react-router`).
+
+## Usage
+
+Use `<Link>` anywhere you need to navigate to a route within your admin app:
+
+```tsx
+import { Link } from "@/components/admin";
+
+const MyComponent = () => (
+    <Link to="/posts">Go to Posts</Link>
+);
+```
+
+`<Link>` works exactly like a standard anchor element, but delegates the actual routing to the router configured via ra-core's `RouterProvider`. This means your components will work regardless of the underlying routing library.
+
+## Why Not Import `Link` From `react-router` Directly?
+
+Importing `Link` from `react-router` directly in UI components creates a tight coupling between your component layer and a specific routing implementation. This has several drawbacks:
+
+- **Portability**: Components can't be reused in apps that use a different router (e.g., TanStack Router).
+- **Consistency**: react-admin's core layer already provides a router abstraction via `RouterProvider`. Bypassing it means some links go through the abstraction while others don't.
+- **Future-proofing**: If the project ever switches routers, every direct import must be found and updated.
+
+The `<Link>` component solves this by delegating to ra-core's `LinkBase`, which reads the router from context. This is the same approach react-admin uses in its MUI layer ([`ra-ui-materialui/Link`](https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/src/Link.tsx)).
+
+**Instead of:**
+
+```tsx
+// ❌ Couples the component to react-router
+import { Link } from "react-router";
+
+<Link to="/posts">Posts</Link>
+```
+
+**Use:**
+
+```tsx
+// ✅ Router-agnostic
+import { Link } from "@/components/admin";
+
+<Link to="/posts">Posts</Link>
+```
+
+## Use With Breadcrumb
+
+When building custom breadcrumbs, use `<Link>` for the intermediate items:
+
+```tsx
+import { Edit, Breadcrumb, Link, SimpleForm } from "@/components/admin";
+import { RecordRepresentation } from "ra-core";
+
+const PostEdit = () => (
+    <Edit disableBreadcrumb>
+        <Breadcrumb>
+            <Breadcrumb.Item><Link to="/">Home</Link></Breadcrumb.Item>
+            <Breadcrumb.Item><Link to="/posts">Articles</Link></Breadcrumb.Item>
+            <Breadcrumb.PageItem>
+                Edit Article "<RecordRepresentation />"
+            </Breadcrumb.PageItem>
+        </Breadcrumb>
+        <SimpleForm>
+            ...
+        </SimpleForm>
+    </Edit>
+);
+```
+
+## Props
+
+| Prop | Required | Type | Default | Description |
+|------|----------|------|---------|-------------|
+| `to` | Required | `string \| Partial<Location>` | - | The target route |
+| `replace` | Optional | `boolean` | `false` | Replace the current history entry instead of pushing |
+| `state` | Optional | `any` | - | State to pass to the target route |
+| `className` | Optional | `string` | - | CSS class name |
+| `children` | Optional | `ReactNode` | - | Link content |
+
+`<Link>` also accepts any additional HTML anchor attributes (e.g., `onClick`, `aria-label`).
+
+## `to`
+
+The target route. Can be a string path or a location object:
+
+```tsx
+// String path
+<Link to="/posts">Posts</Link>
+
+// Location object
+<Link to={{ pathname: "/posts", search: "?sort=name" }}>
+    Posts
+</Link>
+```

--- a/src/components/admin/app-sidebar.tsx
+++ b/src/components/admin/app-sidebar.tsx
@@ -7,7 +7,8 @@ import {
   useResourceDefinitions,
   useTranslate,
 } from "ra-core";
-import { Link, useMatch } from "react-router";
+import { useMatch } from "ra-core";
+import { Link } from "@/components/admin/link";
 import {
   Sidebar,
   SidebarContent,

--- a/src/components/admin/authentication.tsx
+++ b/src/components/admin/authentication.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "@/components/admin/link";
 import { Translate, useHandleAuthCallback, useTranslate } from "ra-core";
 import { CircleAlert, LockIcon } from "lucide-react";
 import { cn } from "@/lib/utils";

--- a/src/components/admin/breadcrumb.tsx
+++ b/src/components/admin/breadcrumb.tsx
@@ -38,7 +38,7 @@ import { Translate } from "ra-core";
  * @example
  * import { Edit, Breadcrumb, SimpleForm } from "@/components/admin";
  * import { RecordRepresentation } from 'ra-core';
- * import { Link } from "react-router";
+ * import { Link } from "@/components/admin";
  *
  * const PostEdit = () => (
  *   <Edit disableBreadcrumb>

--- a/src/components/admin/count.tsx
+++ b/src/components/admin/count.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import type { SortPayload } from "ra-core";
 import {
   useResourceContext,
@@ -7,7 +8,7 @@ import {
 } from "ra-core";
 import { CircleX, LoaderCircle } from "lucide-react";
 
-import { Link } from "react-router";
+import { Link } from "@/components/admin/link";
 
 /**
  * Fetches and displays the item count for a resource.
@@ -74,7 +75,7 @@ export const Count = (props: CountProps) => {
         pathname: createPath({ resource, type: "list" }),
         search: filter ? `filter=${JSON.stringify(filter)}` : undefined,
       }}
-      onClick={(e) => e.stopPropagation()}
+      onClick={(e: React.MouseEvent) => e.stopPropagation()}
       {...rest}
     >
       {body}

--- a/src/components/admin/create-button.tsx
+++ b/src/components/admin/create-button.tsx
@@ -7,7 +7,7 @@ import {
   useResourceContext,
   useResourceTranslation,
 } from "ra-core";
-import { Link } from "react-router";
+import { Link } from "@/components/admin/link";
 
 export type CreateButtonProps = {
   label?: string;

--- a/src/components/admin/create.tsx
+++ b/src/components/admin/create.tsx
@@ -14,7 +14,7 @@ import {
   useResourceContext,
 } from "ra-core";
 import type { ReactNode } from "react";
-import { Link } from "react-router";
+import { Link } from "@/components/admin/link";
 import { cn } from "@/lib/utils";
 
 export type CreateProps = CreateViewProps & CreateBaseProps;

--- a/src/components/admin/edit-button.tsx
+++ b/src/components/admin/edit-button.tsx
@@ -10,7 +10,7 @@ import {
   useResourceContext,
   useResourceTranslation,
 } from "ra-core";
-import { Link } from "react-router";
+import { Link } from "@/components/admin/link";
 
 export type EditButtonProps = {
   record?: RaRecord;

--- a/src/components/admin/edit.tsx
+++ b/src/components/admin/edit.tsx
@@ -11,7 +11,7 @@ import {
   useResourceDefinition,
 } from "ra-core";
 import type { ReactNode } from "react";
-import { Link } from "react-router";
+import { Link } from "@/components/admin/link";
 import {
   Breadcrumb,
   BreadcrumbItem,

--- a/src/components/admin/index.ts
+++ b/src/components/admin/index.ts
@@ -35,6 +35,7 @@ export * from "./file-input";
 export * from "./filter-form";
 export * from "./form";
 export * from "./layout";
+export * from "./link";
 export * from "./list-guesser";
 export * from "./list-pagination";
 export * from "./list";

--- a/src/components/admin/link.tsx
+++ b/src/components/admin/link.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import { LinkBase, type LinkBaseProps } from "ra-core";
+import { cn } from "@/lib/utils";
+
+/**
+ * A router-agnostic Link component for use in admin UI.
+ *
+ * Wraps ra-core's `LinkBase` with shadcn/ui-compatible styling. This provides a routing
+ * abstraction layer so that components are not directly coupled to a specific router package.
+ *
+ * @see {@link https://marmelab.com/shadcn-admin-kit/docs/link/ Link documentation}
+ *
+ * @example
+ * import { Link } from "@/components/admin";
+ *
+ * const MyComponent = () => (
+ *   <Link to="/posts">Go to Posts</Link>
+ * );
+ */
+export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
+  ({ className, ...props }, ref) => {
+    return <LinkBase ref={ref} className={cn(className)} {...props} />;
+  },
+);
+Link.displayName = "Link";
+
+export interface LinkProps extends LinkBaseProps {
+  className?: string;
+}

--- a/src/components/admin/link.tsx
+++ b/src/components/admin/link.tsx
@@ -1,11 +1,10 @@
 import * as React from "react";
 import { LinkBase, type LinkBaseProps } from "ra-core";
-import { cn } from "@/lib/utils";
 
 /**
  * A router-agnostic Link component for use in admin UI.
  *
- * Wraps ra-core's `LinkBase` with shadcn/ui-compatible styling. This provides a routing
+ * Wraps ra-core's `LinkBase` for admin UI. This provides a routing
  * abstraction layer so that components are not directly coupled to a specific router package.
  *
  * @see {@link https://marmelab.com/shadcn-admin-kit/docs/link/ Link documentation}
@@ -18,12 +17,10 @@ import { cn } from "@/lib/utils";
  * );
  */
 export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
-  ({ className, ...props }, ref) => {
-    return <LinkBase ref={ref} className={cn(className)} {...props} />;
+  (props, ref) => {
+    return <LinkBase ref={ref} {...props} />;
   },
 );
 Link.displayName = "Link";
 
-export interface LinkProps extends LinkBaseProps {
-  className?: string;
-}
+export type LinkProps = LinkBaseProps;

--- a/src/components/admin/link.tsx
+++ b/src/components/admin/link.tsx
@@ -1,6 +1,3 @@
-import * as React from "react";
-import { LinkBase, type LinkBaseProps } from "ra-core";
-
 /**
  * A router-agnostic Link component for use in admin UI.
  *
@@ -16,11 +13,4 @@ import { LinkBase, type LinkBaseProps } from "ra-core";
  *   <Link to="/posts">Go to Posts</Link>
  * );
  */
-export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
-  (props, ref) => {
-    return <LinkBase ref={ref} {...props} />;
-  },
-);
-Link.displayName = "Link";
-
-export type LinkProps = LinkBaseProps;
+export { LinkBase as Link, type LinkBaseProps as LinkProps } from "ra-core";

--- a/src/components/admin/list.tsx
+++ b/src/components/admin/list.tsx
@@ -15,7 +15,7 @@ import {
   useTranslate,
 } from "ra-core";
 import type { ReactElement, ReactNode } from "react";
-import { Link } from "react-router";
+import { Link } from "@/components/admin/link";
 import { cn } from "@/lib/utils";
 import { CreateButton } from "@/components/admin/create-button";
 import { ExportButton } from "@/components/admin/export-button";

--- a/src/components/admin/reference-field.tsx
+++ b/src/components/admin/reference-field.tsx
@@ -12,7 +12,7 @@ import {
   useTranslate,
 } from "ra-core";
 import type { MouseEvent, ReactNode } from "react";
-import { Link } from "react-router";
+import { Link } from "@/components/admin/link";
 import type { UseQueryOptions } from "@tanstack/react-query";
 
 /**

--- a/src/components/admin/reference-many-count.tsx
+++ b/src/components/admin/reference-many-count.tsx
@@ -1,10 +1,11 @@
+import React from "react";
 import type { RaRecord, SortPayload } from "ra-core";
 import {
   useCreatePath,
   useRecordContext,
   useReferenceManyFieldController,
 } from "ra-core";
-import { Link } from "react-router";
+import { Link } from "@/components/admin/link";
 
 /**
  * Displays the count of related records that reference the current record.
@@ -67,7 +68,7 @@ export const ReferenceManyCount = <RecordType extends RaRecord = RaRecord>(
           [target]: record[source],
         })}`,
       }}
-      onClick={(e) => e.stopPropagation()}
+      onClick={(e: React.MouseEvent) => e.stopPropagation()}
     >
       {body}
     </Link>

--- a/src/components/admin/show-button.tsx
+++ b/src/components/admin/show-button.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "react-router";
+import { Link } from "@/components/admin/link";
 import { buttonVariants } from "@/components/ui/button";
 import { Eye } from "lucide-react";
 import type { RaRecord } from "ra-core";

--- a/src/components/admin/show.tsx
+++ b/src/components/admin/show.tsx
@@ -16,7 +16,7 @@ import {
   useResourceDefinition,
 } from "ra-core";
 import type { ReactNode } from "react";
-import { Link } from "react-router";
+import { Link } from "@/components/admin/link";
 import { cn } from "@/lib/utils";
 import { EditButton } from "@/components/admin/edit-button";
 

--- a/src/stories/breadcrumb.stories.tsx
+++ b/src/stories/breadcrumb.stories.tsx
@@ -13,7 +13,7 @@ import {
   Breadcrumb,
 } from "@/components/admin";
 import { i18nProvider } from "@/lib/i18nProvider";
-import { Link } from "react-router";
+import { Link } from "@/components/admin/link";
 
 export default {
   title: "Layout/Breadcrumb",


### PR DESCRIPTION
## Problem

Admin components and stories directly import `Link` from `react-router`, coupling the UI layer to a specific routing implementation. This makes components less portable and harder to reuse across different routing strategies (e.g., TanStack Router).

## Solution

Create a `Link` component in `src/components/admin/link.tsx` that wraps `LinkBase` from `ra-core`, following the same approach react-admin uses in its MUI layer ([`ra-ui-materialui/src/Link.tsx`](https://github.com/marmelab/react-admin/blob/master/packages/ra-ui-materialui/src/Link.tsx)). Replace all direct `import { Link } from "react-router"` in admin components and stories with this new abstraction.

**New file:** `src/components/admin/link.tsx`

**Updated imports (14 files):** `app-sidebar`, `authentication`, `breadcrumb` (JSDoc), `count`, `create-button`, `create`, `edit-button`, `edit`, `list`, `reference-field`, `reference-many-count`, `show-button`, `show`, `breadcrumb.stories.tsx`

## How To Test

1. Run `make typecheck` — should pass with no errors
2. Run `make test` — all 126 tests should pass
3. Start the dev server (`make run`) and navigate through the app:
   - Verify sidebar links work (dashboard, resource lists)
   - Verify breadcrumb links on List, Show, Edit, and Create pages
   - Verify Create, Edit, and Show buttons navigate correctly
   - Verify ReferenceField and ReferenceManyCount links work

## Additional Checks

- [x] The PR includes **unit tests** — existing specs for `create-button`, `edit-button`, and `show-button` cover the change; no new component logic was introduced
- [x] The PR includes one or several **stories** — the existing `breadcrumb.stories.tsx` was updated to use the new `Link`; a dedicated `Link` story is not necessary because it is a simple wrapper for LinkBase from `react-admin`
- [x] The **documentation** is up to date — added `docs/src/content/docs/Link.md` with usage, rationale, and props; updated `Breadcrumb.md` examples; added `link` to the sidebar in `astro.config.mjs`
