### PR TITLE
Fix missing default storeKey in DataTable component

### DIFF
--- a/src/components/admin/data-table.tsx
+++ b/src/components/admin/data-table.tsx
@@ -95,11 +95,12 @@ export function DataTable<RecordType extends RaRecord = RaRecord>(
     rowClassName,
     bulkActionButtons = defaultBulkActionButtons,
     bulkActionsToolbar,
+    storeKey: storeKeyProp,
     ...rest
   } = props;
   const hasBulkActions = !!bulkActionsToolbar || bulkActionButtons !== false;
   const resourceFromContext = useResourceContext(props);
-  const storeKey = props.storeKey || `${resourceFromContext}.datatable`;
+  const storeKey = storeKeyProp || `${resourceFromContext}.datatable`;
   const [columnRanks] = useStore<number[]>(`${storeKey}_columnRanks`);
   const columns = columnRanks
     ? reorderChildren(children, columnRanks)
@@ -110,6 +111,7 @@ export function DataTable<RecordType extends RaRecord = RaRecord>(
       hasBulkActions={hasBulkActions}
       loading={null}
       empty={<DataTableEmpty />}
+      storeKey={storeKey}
       {...rest}
     >
       <div className={cn("rounded-md border", className)}>


### PR DESCRIPTION
## Problem

The DataTable component lacks a default `storeKey`, which can lead to unexpected behavior when the `storeKey` prop is not provided.
Maybe there is something I'm missing

## Solution

This update allows the `storeKey` to be passed as a prop, ensuring that a default value is used when it is not specified.

## How To Test

1. Render the DataTable component without the `storeKey` prop.
2. Verify that the default `storeKey` is correctly generated based on the resource context.
3. Render the DataTable component with a custom `storeKey` prop and ensure it uses the provided value.

## Additional Checks

- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [ ] ~The **documentation** is up to date~ → Not needed

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/shadcn-admin-kit#contributing).

