### PR TITLE
fix: replace Github icon with GitBranch

### DIFF
--- a/src/components/admin/ready.tsx
+++ b/src/components/admin/ready.tsx
@@ -2,7 +2,7 @@ import {
   ScanFace,
   BookOpenText,
   ChevronsLeftRight,
-  Github,
+  GitBranch,
 } from "lucide-react";
 
 /**
@@ -46,7 +46,7 @@ export const Ready = () => (
       </div>
       <div className="text-xl">
         <a href="https://github.com/marmelab/shadcn-admin-kit">
-          <Github className="inline mr-4 w-10 h-10" />
+          <GitBranch className="inline mr-4 w-10 h-10" />
           GitHub
         </a>
       </div>


### PR DESCRIPTION
## Problem

Fixes #159 

The ready component uses the GitHub icon from Lucide but brand icons were removed in Lucide version 1. New users following the [installation tutorial](https://marmelab.com/shadcn-admin-kit/docs/install/) get the latest version of lucide-react, causing the Ready screen to break immediately with a runtime error.

## Solution

Replace the Github icon with GitBranch

## How To Test

1. `make run`
2. Delete or comment out the `<Resource>` children in `src/demo/App.tsx` to render the Ready component
3. Confirm the page loads without error and the GitBranch icon appears next to the GitHub link

## Additional Checks

- [x] The PR includes **no unit tests** (because this is a visual only change)
- [x] The PR includes **no stories** (because this is a visual only change)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/shadcn-admin-kit#contributing).
