### PR TITLE
Add ability to use TanStack Router instead of react-router

### DIFF
--- a/src/components/admin/app-sidebar.tsx
+++ b/src/components/admin/app-sidebar.tsx
@@ -6,8 +6,9 @@ import {
   useHasDashboard,
   useResourceDefinitions,
   useTranslate,
+  LinkBase,
+  useMatch,
 } from "ra-core";
-import { Link, useMatch } from "react-router";
 import {
   Sidebar,
   SidebarContent,
@@ -53,10 +54,10 @@ export function AppSidebar() {
               asChild
               className="data-[slot=sidebar-menu-button]:!p-1.5"
             >
-              <Link to="/">
+              <LinkBase to="/">
                 <Shell className="!size-5" />
                 <span className="text-base font-semibold">Acme Inc.</span>
-              </Link>
+              </LinkBase>
             </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>
@@ -104,10 +105,10 @@ export const DashboardMenuItem = ({ onClick }: { onClick?: () => void }) => {
   return (
     <SidebarMenuItem>
       <SidebarMenuButton asChild isActive={!!match}>
-        <Link to="/" onClick={onClick}>
+        <LinkBase to="/" onClick={onClick}>
           <House />
           {label}
-        </Link>
+        </LinkBase>
       </SidebarMenuButton>
     </SidebarMenuItem>
   );
@@ -152,14 +153,14 @@ export const ResourceMenuItem = ({
   return (
     <SidebarMenuItem>
       <SidebarMenuButton asChild isActive={!!match}>
-        <Link to={to} state={{ _scrollToTop: true }} onClick={onClick}>
+        <LinkBase to={to} state={{ _scrollToTop: true }} onClick={onClick}>
           {resources[name].icon ? (
             createElement(resources[name].icon)
           ) : (
             <List />
           )}
           {getResourceLabel(name, 2)}
-        </Link>
+        </LinkBase>
       </SidebarMenuButton>
     </SidebarMenuItem>
   );

--- a/src/components/admin/authentication.tsx
+++ b/src/components/admin/authentication.tsx
@@ -1,5 +1,9 @@
-import { Link } from "react-router";
-import { Translate, useHandleAuthCallback, useTranslate } from "ra-core";
+import {
+  LinkBase,
+  Translate,
+  useHandleAuthCallback,
+  useTranslate,
+} from "ra-core";
 import { CircleAlert, LockIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -77,9 +81,9 @@ export const AuthError = (props: AuthErrorProps) => {
       </h1>
       <p className="my-5">{translate(message, { _: message })}</p>
       <Button asChild>
-        <Link to="/login">
+        <LinkBase to="/login">
           <LockIcon /> {translate("ra.auth.sign_in", { _: "Sign in" })}
-        </Link>
+        </LinkBase>
       </Button>
     </div>
   );

--- a/src/components/admin/boolean-field.tsx
+++ b/src/components/admin/boolean-field.tsx
@@ -1,7 +1,7 @@
 import { Check, type LucideIcon, X } from "lucide-react";
 import { RaRecord, useFieldValue, useTranslate } from "ra-core";
 
-import type { FieldProps } from "@/lib/field.type";
+import type { FieldProps } from "@/lib/field.type.ts";
 import { cn } from "@/lib/utils";
 import {
   Tooltip,

--- a/src/components/admin/breadcrumb.tsx
+++ b/src/components/admin/breadcrumb.tsx
@@ -37,17 +37,16 @@ import { Translate } from "ra-core";
  *
  * @example
  * import { Edit, Breadcrumb, SimpleForm } from "@/components/admin";
- * import { RecordRepresentation } from 'ra-core';
- * import { Link } from "react-router";
+ * import { LinkBase, RecordRepresentation } from 'ra-core';
  *
  * const PostEdit = () => (
  *   <Edit disableBreadcrumb>
  *     <Breadcrumb>
- *       <Breadcrumb.Item><Link to="/">Home</Link></Breadcrumb.Item>
- *       <Breadcrumb.Item><Link to="/posts">Articles</Link></Breadcrumb.Item>
+ *       <Breadcrumb.Item><LinkBase to="/">Home</LinkBase></Breadcrumb.Item>
+ *       <Breadcrumb.Item><LinkBase to="/posts">Articles</LinkBase></Breadcrumb.Item>
  *       <Breadcrumb.PageItem>
  *         Edit Article "<RecordRepresentation />"
- *       </Breadcrumb.Item>
+ *       </Breadcrumb.PageItem>
  *     </Breadcrumb>
  *     <SimpleForm>
  *       ...

--- a/src/components/admin/cancel-button.tsx
+++ b/src/components/admin/cancel-button.tsx
@@ -1,6 +1,5 @@
 import { CircleX } from "lucide-react";
-import { Translate } from "ra-core";
-import { useNavigate } from "react-router";
+import { Translate, useNavigate } from "ra-core";
 
 import { Button } from "../ui/button";
 

--- a/src/components/admin/count.tsx
+++ b/src/components/admin/count.tsx
@@ -1,13 +1,12 @@
 import type { SortPayload } from "ra-core";
 import {
+  LinkBase,
   useResourceContext,
   useGetList,
   useTimeout,
   useCreatePath,
 } from "ra-core";
 import { CircleX, LoaderCircle } from "lucide-react";
-
-import { Link } from "react-router";
 
 /**
  * Fetches and displays the item count for a resource.
@@ -69,16 +68,16 @@ export const Count = (props: CountProps) => {
   );
 
   return link ? (
-    <Link
+    <LinkBase
       to={{
         pathname: createPath({ resource, type: "list" }),
         search: filter ? `filter=${JSON.stringify(filter)}` : undefined,
       }}
-      onClick={(e) => e.stopPropagation()}
+      onClick={(e: React.MouseEvent<HTMLAnchorElement>) => e.stopPropagation()}
       {...rest}
     >
       {body}
-    </Link>
+    </LinkBase>
   ) : (
     <span {...rest}>{body}</span>
   );

--- a/src/components/admin/create-button.tsx
+++ b/src/components/admin/create-button.tsx
@@ -2,12 +2,12 @@ import React from "react";
 import { buttonVariants } from "@/components/ui/button";
 import { Plus } from "lucide-react";
 import {
+  LinkBase,
   useCreatePath,
   useGetResourceLabel,
   useResourceContext,
   useResourceTranslation,
 } from "ra-core";
-import { Link } from "react-router";
 
 export type CreateButtonProps = {
   label?: string;
@@ -55,7 +55,7 @@ export const CreateButton = (props: CreateButtonProps) => {
     userText: labelProp,
   });
   return (
-    <Link
+    <LinkBase
       className={buttonVariants({ variant: "outline" })}
       to={link}
       onClick={stopPropagation}
@@ -63,7 +63,7 @@ export const CreateButton = (props: CreateButtonProps) => {
     >
       <Plus />
       {label}
-    </Link>
+    </LinkBase>
   );
 };
 

--- a/src/components/admin/create.tsx
+++ b/src/components/admin/create.tsx
@@ -5,6 +5,7 @@ import {
 } from "@/components/admin/breadcrumb";
 import type { CreateBaseProps } from "ra-core";
 import {
+  LinkBase,
   CreateBase,
   Translate,
   useCreateContext,
@@ -14,7 +15,6 @@ import {
   useResourceContext,
 } from "ra-core";
 import type { ReactNode } from "react";
-import { Link } from "react-router";
 import { cn } from "@/lib/utils";
 
 export type CreateProps = CreateViewProps & CreateBaseProps;
@@ -102,13 +102,13 @@ export const CreateView = ({
         <Breadcrumb>
           {hasDashboard && (
             <BreadcrumbItem>
-              <Link to="/">
+              <LinkBase to="/">
                 <Translate i18nKey="ra.page.dashboard">Home</Translate>
-              </Link>
+              </LinkBase>
             </BreadcrumbItem>
           )}
           <BreadcrumbItem>
-            <Link to={listLink}>{listLabel}</Link>
+            <LinkBase to={listLink}>{listLabel}</LinkBase>
           </BreadcrumbItem>
           <BreadcrumbPage>
             <Translate i18nKey="ra.action.create">Create</Translate>

--- a/src/components/admin/data-table.tsx
+++ b/src/components/admin/data-table.tsx
@@ -26,8 +26,8 @@ import {
   useStore,
   useTranslate,
   useTranslateLabel,
+  useNavigate,
 } from "ra-core";
-import { useNavigate } from "react-router";
 import { ArrowDownAZ, ArrowUpZA } from "lucide-react";
 import get from "lodash/get";
 import { cn } from "@/lib/utils";

--- a/src/components/admin/edit-button.tsx
+++ b/src/components/admin/edit-button.tsx
@@ -3,6 +3,7 @@ import { buttonVariants } from "@/components/ui/button";
 import { Pencil } from "lucide-react";
 import type { RaRecord } from "ra-core";
 import {
+  LinkBase,
   useCreatePath,
   useGetRecordRepresentation,
   useGetResourceLabel,
@@ -10,7 +11,6 @@ import {
   useResourceContext,
   useResourceTranslation,
 } from "ra-core";
-import { Link } from "react-router";
 
 export type EditButtonProps = {
   record?: RaRecord;
@@ -66,7 +66,7 @@ export const EditButton = (props: EditButtonProps) => {
     userText: labelProp,
   });
   return (
-    <Link
+    <LinkBase
       className={buttonVariants({ variant: "outline" })}
       to={link}
       onClick={stopPropagation}
@@ -74,7 +74,7 @@ export const EditButton = (props: EditButtonProps) => {
     >
       <Pencil />
       {label}
-    </Link>
+    </LinkBase>
   );
 };
 

--- a/src/components/admin/edit.tsx
+++ b/src/components/admin/edit.tsx
@@ -1,6 +1,7 @@
 import type { EditBaseProps } from "ra-core";
 import {
   EditBase,
+  LinkBase,
   Translate,
   useCreatePath,
   useEditContext,
@@ -11,7 +12,6 @@ import {
   useResourceDefinition,
 } from "ra-core";
 import type { ReactNode } from "react";
-import { Link } from "react-router";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -119,13 +119,13 @@ export const EditView = ({
         <Breadcrumb>
           {hasDashboard && (
             <BreadcrumbItem>
-              <Link to="/">
+              <LinkBase to="/">
                 <Translate i18nKey="ra.page.dashboard">Home</Translate>
-              </Link>
+              </LinkBase>
             </BreadcrumbItem>
           )}
           <BreadcrumbItem>
-            <Link to={listLink}>{listLabel}</Link>
+            <LinkBase to={listLink}>{listLabel}</LinkBase>
           </BreadcrumbItem>
           <BreadcrumbPage>{recordRepresentation}</BreadcrumbPage>
         </Breadcrumb>

--- a/src/components/admin/filter-form.tsx
+++ b/src/components/admin/filter-form.tsx
@@ -12,11 +12,11 @@ import {
   type SavedQuery,
   useFilterContext,
   useListContext,
+  useNavigate,
   useResourceContext,
   useSavedQueries,
   useTranslate,
 } from "ra-core";
-import { useNavigate } from "react-router";
 import {
   Bookmark,
   BookmarkMinus,

--- a/src/components/admin/list-guesser.tsx
+++ b/src/components/admin/list-guesser.tsx
@@ -7,10 +7,10 @@ import {
   getElementsFromRecords,
   InferredElement,
   useListContext,
+  useLocation,
   usePrevious,
   useResourceContext,
 } from "ra-core";
-import { useLocation } from "react-router";
 import type { ListProps, ListViewProps } from "@/components/admin/list";
 import { ListView } from "@/components/admin/list";
 import { capitalize, singularize } from "inflection";

--- a/src/components/admin/list.tsx
+++ b/src/components/admin/list.tsx
@@ -6,6 +6,7 @@ import {
 import type { ListBaseProps, ListControllerResult, RaRecord } from "ra-core";
 import {
   FilterContext,
+  LinkBase,
   ListBase,
   Translate,
   useGetResourceLabel,
@@ -15,7 +16,6 @@ import {
   useTranslate,
 } from "ra-core";
 import type { ReactElement, ReactNode } from "react";
-import { Link } from "react-router";
 import { cn } from "@/lib/utils";
 import { CreateButton } from "@/components/admin/create-button";
 import { ExportButton } from "@/components/admin/export-button";
@@ -132,9 +132,9 @@ export const ListView = <RecordType extends RaRecord = RaRecord>(
         <Breadcrumb>
           {hasDashboard && (
             <BreadcrumbItem>
-              <Link to="/">
+              <LinkBase to="/">
                 <Translate i18nKey="ra.page.dashboard">Home</Translate>
-              </Link>
+              </LinkBase>
             </BreadcrumbItem>
           )}
           <BreadcrumbPage>{resourceLabel}</BreadcrumbPage>

--- a/src/components/admin/reference-field.tsx
+++ b/src/components/admin/reference-field.tsx
@@ -5,6 +5,7 @@ import type {
   UseReferenceFieldControllerResult,
 } from "ra-core";
 import {
+  LinkBase,
   ReferenceFieldBase,
   useFieldValue,
   useGetRecordRepresentation,
@@ -12,7 +13,6 @@ import {
   useTranslate,
 } from "ra-core";
 import type { MouseEvent, ReactNode } from "react";
-import { Link } from "react-router";
 import type { UseQueryOptions } from "@tanstack/react-query";
 
 /**
@@ -126,9 +126,9 @@ export const ReferenceFieldView = <
   if (link) {
     return (
       <span className={className}>
-        <Link to={link} onClick={stopPropagation}>
+        <LinkBase to={link} onClick={stopPropagation}>
           {child}
-        </Link>
+        </LinkBase>
       </span>
     );
   }

--- a/src/components/admin/reference-many-count.tsx
+++ b/src/components/admin/reference-many-count.tsx
@@ -1,10 +1,10 @@
 import type { RaRecord, SortPayload } from "ra-core";
 import {
+  LinkBase,
   useCreatePath,
   useRecordContext,
   useReferenceManyFieldController,
 } from "ra-core";
-import { Link } from "react-router";
 
 /**
  * Displays the count of related records that reference the current record.
@@ -59,7 +59,7 @@ export const ReferenceManyCount = <RecordType extends RaRecord = RaRecord>(
   const body = isLoading ? "" : error ? "error" : total;
 
   return link && record ? (
-    <Link
+    <LinkBase
       to={{
         pathname: createPath({ resource: reference, type: "list" }),
         search: `filter=${JSON.stringify({
@@ -67,10 +67,10 @@ export const ReferenceManyCount = <RecordType extends RaRecord = RaRecord>(
           [target]: record[source],
         })}`,
       }}
-      onClick={(e) => e.stopPropagation()}
+      onClick={(e: React.MouseEvent<HTMLAnchorElement>) => e.stopPropagation()}
     >
       {body}
-    </Link>
+    </LinkBase>
   ) : (
     <span>{body}</span>
   );

--- a/src/components/admin/show-button.tsx
+++ b/src/components/admin/show-button.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { Link } from "react-router";
 import { buttonVariants } from "@/components/ui/button";
 import { Eye } from "lucide-react";
 import type { RaRecord } from "ra-core";
 import {
+  LinkBase,
   useCreatePath,
   useGetRecordRepresentation,
   useGetResourceLabel,
@@ -66,7 +66,7 @@ export const ShowButton = (props: ShowButtonProps) => {
     userText: labelProp,
   });
   return (
-    <Link
+    <LinkBase
       className={buttonVariants({ variant: "outline" })}
       to={link}
       onClick={stopPropagation}
@@ -75,7 +75,7 @@ export const ShowButton = (props: ShowButtonProps) => {
     >
       {icon ?? <Eye />}
       {label}
-    </Link>
+    </LinkBase>
   );
 };
 

--- a/src/components/admin/show.tsx
+++ b/src/components/admin/show.tsx
@@ -5,6 +5,7 @@ import {
 } from "@/components/admin/breadcrumb";
 import type { ShowBaseProps } from "ra-core";
 import {
+  LinkBase,
   ShowBase,
   Translate,
   useCreatePath,
@@ -16,7 +17,6 @@ import {
   useResourceDefinition,
 } from "ra-core";
 import type { ReactNode } from "react";
-import { Link } from "react-router";
 import { cn } from "@/lib/utils";
 import { EditButton } from "@/components/admin/edit-button";
 
@@ -151,13 +151,13 @@ export const ShowView = ({
         <Breadcrumb>
           {hasDashboard && (
             <BreadcrumbItem>
-              <Link to="/">
+              <LinkBase to="/">
                 <Translate i18nKey="ra.page.dashboard">Home</Translate>
-              </Link>
+              </LinkBase>
             </BreadcrumbItem>
           )}
           <BreadcrumbItem>
-            <Link to={listLink}>{listLabel}</Link>
+            <LinkBase to={listLink}>{listLabel}</LinkBase>
           </BreadcrumbItem>
           <BreadcrumbPage>{recordRepresentation}</BreadcrumbPage>
         </Breadcrumb>

--- a/src/stories/breadcrumb.stories.tsx
+++ b/src/stories/breadcrumb.stories.tsx
@@ -1,4 +1,4 @@
-import { Resource, TestMemoryRouter } from "ra-core";
+import { LinkBase, Resource, TestMemoryRouter } from "ra-core";
 import fakeRestProvider from "ra-data-fakerest";
 import {
   Admin,
@@ -13,7 +13,6 @@ import {
   Breadcrumb,
 } from "@/components/admin";
 import { i18nProvider } from "@/lib/i18nProvider";
-import { Link } from "react-router";
 
 export default {
   title: "Layout/Breadcrumb",
@@ -212,7 +211,7 @@ const ShowWithCustomBreadcrumb = () => (
   <Show disableBreadcrumb>
     <Breadcrumb>
       <Breadcrumb.Item>
-        <Link to="/products">Products</Link>
+        <LinkBase to="/products">Products</LinkBase>
       </Breadcrumb.Item>
       <Breadcrumb.PageItem>Show Product</Breadcrumb.PageItem>
     </Breadcrumb>
@@ -224,7 +223,7 @@ const EditWithCustomBreadcrumb = () => (
   <Edit disableBreadcrumb>
     <Breadcrumb>
       <Breadcrumb.Item>
-        <Link to="/products">Products</Link>
+        <LinkBase to="/products">Products</LinkBase>
       </Breadcrumb.Item>
       <Breadcrumb.PageItem>Edit Product</Breadcrumb.PageItem>
     </Breadcrumb>
@@ -236,7 +235,7 @@ const CreateWithCustomBreadcrumb = () => (
   <Create disableBreadcrumb>
     <Breadcrumb>
       <Breadcrumb.Item>
-        <Link to="/products">Products</Link>
+        <LinkBase to="/products">Products</LinkBase>
       </Breadcrumb.Item>
       <Breadcrumb.PageItem>Create Product</Breadcrumb.PageItem>
     </Breadcrumb>


### PR DESCRIPTION
## Problem

Admin components and stories directly import `Link` from `react-router`, coupling the UI layer to a specific routing implementation. This makes components less portable and harder to reuse across different routing strategies (e.g., TanStack Router).

## Solution

Use routing primitives from `ra-core` instead of the ones from `react-router`.

Developers are free to use either react-router's `Link` or ra-core's `LinkBase` in their custom components. 

Supersedes #153