### PR TITLE
fix: Fixed typo in SimpleForm.md Props section

### DIFF
--- a/docs/src/content/docs/SimpleForm.md
+++ b/docs/src/content/docs/SimpleForm.md
@@ -34,7 +34,7 @@ It relies on [react-hook-form](https://react-hook-form.com/) for form handling. 
 |------|----------|------|---------|-------------|
 | `children` | Required | `ReactNode` | - | The form content (usually Input elements). |
 | `className` | Optional | `string` | - | Extra classes appended to base layout |
-| `defaultValues` | Optional | `object| function` | - | The default values of the record. |
+| `defaultValues` | Optional | `object`| `function` | - | The default values of the record. |
 | `id` | Optional | `string` | - | The id of the underlying `<form>` tag. |
 | `noValidate` | Optional | `boolean` | - | Set to `true` to disable the browser's default validation. |
 | `onSubmit` | Optional | `function` | `save` | A callback to call when the form is submitted. |


### PR DESCRIPTION
## Problem

The `SimpleForm.md` documentation in the `Props` section was missing backticks (`).

## Solution

Added the missing closing backticks.

## How To Test

Open the SimpleForm documentation page and navigate to the Props section.

## Additional Checks

- [ ] The PR includes **unit tests** (not required for documentation-only change)
- [ ] The PR includes one or several **stories** (not applicable)
- [ ] The **documentation** is up to date
