### PR TITLE
Add`AutocompleteArrayInput` on the fly option creation

### DIFF
--- a/docs/src/content/docs/AutocompleteArrayInput.md
+++ b/docs/src/content/docs/AutocompleteArrayInput.md
@@ -233,7 +233,9 @@ If you just need to ask users for a single string to create the new option, you 
 If you want to customize the label of the "Create XXX" item, use the `createItemLabel` prop. The `createLabel` prop is the hint displayed instead, as a disabled item, as long as the filter is empty.
 
 :::tip
-Inside a `<ReferenceArrayInput>`, the created record must be part of the choices for its badge to show up. `useCreate` invalidates the list queries of the resource it created, so this works out of the box — unless the `reference` you read the choices from is not the resource you create into (e.g. a database view). In that case, invalidate the `reference` queries yourself.
+Inside a `<ReferenceArrayInput>`, the created record must be part of the choices for its badge to show up.
+`useCreate` invalidates the list queries of the resource it created, so this works out of the box unless the `reference` you read the choices from is not the resource you create into (e.g. a database view).
+In that case, invalidate the `reference` queries yourself.
 :::
 
 ## Working With Object Values

--- a/docs/src/content/docs/AutocompleteArrayInput.md
+++ b/docs/src/content/docs/AutocompleteArrayInput.md
@@ -54,11 +54,15 @@ The form value for the source must be an array of the selected values, e.g.
 | `source` | Required* | `string` | - | Field name (inferred in ReferenceArrayInput) |
 | `choices` | Required* | `any[]` | - | List of choices |
 | `className` | Optional | `string` | - | CSS Classes |
+| `create` | Optional | `Element` | `-` | A React Element to render when users want to create a new choice |
+| `createItemLabel` | Optional | `string` &#124; `(filter: string) => ReactNode` | `ra.action .create_item` | The label for the menu item allowing users to create a new choice. Used when the filter is not empty. |
+| `createLabel` | Optional | `string` &#124; `ReactNode` | - | The label used as hint to let users know they can create a new choice. Displayed when the filter is empty. |
 | `disableValue` | Optional | `string` | `disabled` | The value to use for the disabled state |
 | `filterToQuery` | Optional | `(text:string)=>object` | `{ q: text }` | Server filter mapping |
 | `format` | Optional | `function` | - | Function to convert the value sent by the API to the value used by the form |
 | `helperText` | Optional | `ReactNode` | - | Help text |
 | `inputText` | Optional | `ReactNode \| (choice) =>string` | Choice text | Required if `optionText` is a custom Component, this function must return the text displayed for the current selection.   |
+| `onCreate` | Optional | `Function` | `-` | A function called with the current filter value when users choose to create a new choice. |
 | `optionText` | Optional | `string \| function` | `name` or record repr | Field name of record to display in the suggestion item or function which accepts the correct record as argument (`(record)=> {string}`)  |
 | `optionValue` | Optional | `string` | `id` | Field name of record containing the value to use as input value |
 | `parse` | Optional | `function` | - | Function to convert the value from the form to the value sent to the API |
@@ -138,6 +142,99 @@ const filterToQuery = searchText => ({ name_ilike: `%${searchText}%` });
     <AutocompleteArrayInput filterToQuery={filterToQuery} />
 </ReferenceArrayInput>
 ```
+
+## Creating New Choices On The Fly
+
+Users often discover that a choice is missing while they are filling the form. To let them add it without leaving the page, pass a React element as the `create` prop. `<AutocompleteArrayInput>` then renders an extra item at the bottom of the list, which renders the passed element when clicked. Once created, the new choice is added to the selection.
+
+```tsx
+import {
+    Edit,
+    SimpleForm,
+    ReferenceArrayInput,
+    AutocompleteArrayInput,
+} from '@/components/admin';
+import { useCreate, useCreateSuggestionContext } from 'ra-core';
+
+const CreateTag = () => {
+  const { onCancel, onCreate, filter } = useCreateSuggestionContext();
+  const [newTagName, setNewTagName] = React.useState(filter ?? "");
+  const [create] = useCreate();
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    const newTag = await create(
+      "tags",
+      { data: { name: newTagName } },
+      { returnPromise: true },
+    );
+    setNewTagName("");
+    onCreate(newTag);
+  };
+
+  return (
+    <Dialog open onOpenChange={onCancel}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Create a tag</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="name">New tag name</Label>
+            <Input id="name" value={newTagName} onChange={event => setNewTagName(event.currentTarget.value)} autoFocus />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" type="button" onClick={onCancel}>Cancel</Button>
+            <Button type="submit">Save</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+const PostEdit = () => (
+    <Edit>
+        <SimpleForm>
+            <ReferenceArrayInput source="tag_ids" reference="tags">
+                <AutocompleteArrayInput
+                  create={<CreateTag />}
+                  createLabel="Start typing to create a new tag"
+                  createItemLabel="Create %{item}"
+                />
+            </ReferenceArrayInput>
+        </SimpleForm>
+    </Edit>
+);
+```
+
+The element passed to `create` must call the `useCreateSuggestionContext` hook, which provides:
+
+- `filter`: the text users typed in the input, to use as a default value,
+- `onCreate`: to call with the created choice once saved,
+- `onCancel`: to call when users dismiss the creation.
+
+If you just need to ask users for a single string to create the new option, you can use the `onCreate` prop instead:
+
+```jsx
+<AutocompleteArrayInput
+    source="tags"
+    choices={tags}
+    onCreate={filter => {
+        const newTag = { id: filter.toLowerCase(), name: filter };
+        tags.push(newTag);
+        return newTag;
+    }}
+    createLabel="Start typing to create a new tag"
+    createItemLabel="Create %{item}"
+/>
+```
+
+If you want to customize the label of the "Create XXX" item, use the `createItemLabel` prop. The `createLabel` prop is the hint displayed instead, as a disabled item, as long as the filter is empty.
+
+:::tip
+Inside a `<ReferenceArrayInput>`, the created record must be part of the choices for its badge to show up. `useCreate` invalidates the list queries of the resource it created, so this works out of the box — unless the `reference` you read the choices from is not the resource you create into (e.g. a database view). In that case, invalidate the `reference` queries yourself.
+:::
 
 ## Working With Object Values
 

--- a/docs/src/content/docs/AutocompleteArrayInput.md
+++ b/docs/src/content/docs/AutocompleteArrayInput.md
@@ -147,47 +147,42 @@ const filterToQuery = searchText => ({ name_ilike: `%${searchText}%` });
 
 Users often discover that a choice is missing while they are filling the form. To let them add it without leaving the page, pass a React element as the `create` prop. `<AutocompleteArrayInput>` then renders an extra item at the bottom of the list, which renders the passed element when clicked. Once created, the new choice is added to the selection.
 
+This is generally useful when the choices are fetched from a reference resource, i.e. when using `<ReferenceArrayInput>`:
+
 ```tsx
 import {
     Edit,
     SimpleForm,
     ReferenceArrayInput,
     AutocompleteArrayInput,
+    TextInput,
 } from '@/components/admin';
-import { useCreate, useCreateSuggestionContext } from 'ra-core';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { CreateBase, useCreateSuggestionContext } from 'ra-core';
 
 const CreateTag = () => {
   const { onCancel, onCreate, filter } = useCreateSuggestionContext();
-  const [newTagName, setNewTagName] = React.useState(filter ?? "");
-  const [create] = useCreate();
-
-  const handleSubmit = async (event: React.FormEvent) => {
-    event.preventDefault();
-    const newTag = await create(
-      "tags",
-      { data: { name: newTagName } },
-      { returnPromise: true },
-    );
-    setNewTagName("");
-    onCreate(newTag);
-  };
 
   return (
     <Dialog open onOpenChange={onCancel}>
-      <DialogContent className="sm:max-w-[425px]">
+      <DialogContent>
         <DialogHeader>
           <DialogTitle>Create a tag</DialogTitle>
         </DialogHeader>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="name">New tag name</Label>
-            <Input id="name" value={newTagName} onChange={event => setNewTagName(event.currentTarget.value)} autoFocus />
-          </div>
-          <DialogFooter>
-            <Button variant="outline" type="button" onClick={onCancel}>Cancel</Button>
-            <Button type="submit">Save</Button>
-          </DialogFooter>
-        </form>
+        <CreateBase
+          resource="tags"
+          redirect={false}
+          mutationOptions={{ onSuccess: onCreate }}
+        >
+          <SimpleForm defaultValues={{ name: filter }}>
+            <TextInput source="name" autoFocus />
+          </SimpleForm>
+        </CreateBase>
       </DialogContent>
     </Dialog>
   );
@@ -196,13 +191,17 @@ const CreateTag = () => {
 const PostEdit = () => (
     <Edit>
         <SimpleForm>
-            <ReferenceArrayInput source="tag_ids" reference="tags">
-                <AutocompleteArrayInput
-                  create={<CreateTag />}
-                  createLabel="Start typing to create a new tag"
-                  createItemLabel="Create %{item}"
-                />
-            </ReferenceArrayInput>
+          <ReferenceArrayInput
+            reference="tags"
+            resource="posts"
+            source="tags_ids"
+          >
+            <AutocompleteArrayInput
+              create={<CreateTag />}
+              createLabel="Start typing to create a new tag"
+              createItemLabel="Create %{item}"
+            />
+          </ReferenceArrayInput>
         </SimpleForm>
     </Edit>
 );
@@ -231,12 +230,6 @@ If you just need to ask users for a single string to create the new option, you 
 ```
 
 If you want to customize the label of the "Create XXX" item, use the `createItemLabel` prop. The `createLabel` prop is the hint displayed instead, as a disabled item, as long as the filter is empty.
-
-:::tip
-Inside a `<ReferenceArrayInput>`, the created record must be part of the choices for its badge to show up.
-`useCreate` invalidates the list queries of the resource it created, so this works out of the box unless the `reference` you read the choices from is not the resource you create into (e.g. a database view).
-In that case, invalidate the `reference` queries yourself.
-:::
 
 ## Working With Object Values
 

--- a/src/components/admin/autocomplete-array-input.spec.tsx
+++ b/src/components/admin/autocomplete-array-input.spec.tsx
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 import { render } from "vitest-browser-react";
 import { userEvent } from "vitest/browser";
 
-import { WithMismatchedOptionTextAndValue } from "@/stories/autocomplete-array-input.stories";
+import {
+  Create,
+  OnCreate,
+  WithMismatchedOptionTextAndValue,
+} from "@/stories/autocomplete-array-input.stories";
 
 describe("<AutocompleteArrayInput />", () => {
   it("should filter choices by their text label", async () => {
@@ -33,5 +37,68 @@ describe("<AutocompleteArrayInput />", () => {
     await expect
       .element(filteredOptions.nth(3))
       .toHaveTextContent("UYU - Uruguayan Peso");
+  });
+
+  it("should display a disabled create hint as long as the filter is empty", async () => {
+    const screen = render(<OnCreate />);
+    const searchInput = screen.getByPlaceholder("Search");
+    await searchInput.click();
+
+    // The 8 unselected choices, plus the create hint
+    const options = screen.getByRole("option");
+    expect(options.all()).toHaveLength(9);
+
+    const hint = options.nth(8);
+    await expect
+      .element(hint)
+      .toHaveTextContent("Start typing to create a new tag");
+    await expect.element(hint).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("should offer to create a choice when no choice matches the filter", async () => {
+    const screen = render(<OnCreate />);
+    const searchInput = screen.getByPlaceholder("Search");
+    await searchInput.click();
+    await userEvent.type(searchInput, "gaming");
+
+    // No choice matches "gaming", so only the create option remains
+    await expect.poll(() => screen.getByRole("option").all()).toHaveLength(1);
+    await expect
+      .element(screen.getByRole("option").nth(0))
+      .toHaveTextContent("Create gaming");
+  });
+
+  it("should add the choice created through onCreate to the selection", async () => {
+    const screen = render(<OnCreate />);
+    const searchInput = screen.getByPlaceholder("Search");
+    await searchInput.click();
+    await userEvent.type(searchInput, "gaming");
+
+    await screen.getByRole("option", { name: "Create gaming" }).click();
+
+    // The created choice is now selected, next to the initially selected one
+    await expect.element(screen.getByText("gaming")).toBeInTheDocument();
+    await expect.element(screen.getByText("Tech")).toBeInTheDocument();
+  });
+
+  it("should add the choice created through the create element to the selection", async () => {
+    const screen = render(<Create />);
+    const searchInput = screen.getByPlaceholder("Search");
+    await searchInput.click();
+    await userEvent.type(searchInput, "gaming");
+
+    await screen.getByRole("option", { name: "Create gaming" }).click();
+
+    // The create element receives the filter as default value
+    const dialog = screen.getByRole("dialog");
+    await expect.element(dialog).toHaveTextContent("Create a tag");
+    await expect
+      .element(screen.getByLabelText("New tag name"))
+      .toHaveValue("gaming");
+
+    // scoped to the dialog: the form has a Save button of its own
+    await dialog.getByRole("button", { name: /save/i }).click();
+
+    await expect.element(screen.getByText("gaming")).toBeInTheDocument();
   });
 });

--- a/src/components/admin/autocomplete-array-input.tsx
+++ b/src/components/admin/autocomplete-array-input.tsx
@@ -15,7 +15,11 @@ import {
   FormLabel,
 } from "@/components/admin/form";
 import { Command as CommandPrimitive } from "cmdk";
-import type { ChoicesProps, InputProps } from "ra-core";
+import type {
+  ChoicesProps,
+  InputProps,
+  SupportCreateSuggestionOptions,
+} from "ra-core";
 import {
   useChoices,
   useChoicesContext,
@@ -24,6 +28,7 @@ import {
   useTranslate,
   FieldTitle,
   useEvent,
+  useSupportCreateSuggestion,
 } from "ra-core";
 import { InputHelperText } from "./input-helper-text";
 import { useCallback } from "react";
@@ -32,7 +37,7 @@ import { useCallback } from "react";
  * Form control that lets users choose multiple values from a list using a dropdown with autocompletion.
  *
  * This input allows editing array values with a searchable dropdown interface and displays selected items as removable badges.
- * Works seamlessly inside ReferenceArrayInput for editing many-to-many relationships.
+ * Works seamlessly inside ReferenceArrayInput for creating and editing many-to-many relationships.
  *
  * @see {@link https://marmelab.com/shadcn-admin-kit/docs/autocompletearrayinput/ AutocompleteArrayInput documentation}
  *
@@ -64,6 +69,7 @@ import { useCallback } from "react";
  */
 export const AutocompleteArrayInput = (
   props: Omit<InputProps, "source"> &
+    Omit<SupportCreateSuggestionOptions, "handleChange" | "filter"> &
     Partial<Pick<InputProps, "source">> &
     ChoicesProps & {
       className?: string;
@@ -76,7 +82,17 @@ export const AutocompleteArrayInput = (
         | ((option: any | undefined) => React.ReactNode);
     },
 ) => {
-  const { filterToQuery = DefaultFilterToQuery, inputText } = props;
+  const {
+    filterToQuery = DefaultFilterToQuery,
+    inputText,
+    create,
+    createValue,
+    createLabel,
+    createHintValue,
+    createItemLabel,
+    onCreate,
+    optionText,
+  } = props;
   const {
     allChoices = [],
     source,
@@ -96,6 +112,8 @@ export const AutocompleteArrayInput = (
     optionValue: props.optionValue ?? "id",
     disableValue: props.disableValue,
     translateChoice: props.translateChoice ?? !isFromReference,
+    createValue,
+    createHintValue,
   });
 
   const inputRef = React.useRef<HTMLInputElement>(null);
@@ -144,122 +162,163 @@ export const AutocompleteArrayInput = (
     [inputText, getChoiceText],
   );
 
+  const handleChange = useEvent((choice: any) => {
+    setFilterValue("");
+    if (isFromReference) {
+      setFilters(filterToQuery(""));
+    }
+    const value = getChoiceValue(choice);
+    // a newly created choice may already be selected
+    if (field.value.includes(value)) {
+      return;
+    }
+    field.onChange([...field.value, value]);
+  });
+
+  const {
+    getCreateItem,
+    handleChange: handleChangeWithCreateSupport,
+    createElement,
+    getOptionDisabled,
+  } = useSupportCreateSuggestion({
+    create,
+    createLabel,
+    createValue,
+    createHintValue,
+    createItemLabel,
+    onCreate,
+    handleChange,
+    optionText,
+    filter: filterValue,
+  });
+
+  const createItem =
+    (create || onCreate) && (filterValue !== "" || createLabel)
+      ? getCreateItem(filterValue)
+      : null;
+  const finalChoices = createItem
+    ? [...availableChoices, createItem]
+    : availableChoices;
+
   return (
-    <FormField className={props.className} id={id} name={field.name}>
-      {props.label !== false && (
-        <FormLabel>
-          <FieldTitle
-            label={props.label}
-            source={props.source ?? source}
-            resource={resource}
-            isRequired={isRequired}
-          />
-        </FormLabel>
-      )}
-      <FormControl>
-        <Command
-          onKeyDown={handleKeyDown}
-          shouldFilter={!isFromReference}
-          className="overflow-visible bg-transparent"
-        >
-          <div className="group rounded-md bg-transparent dark:bg-input/30 border border-input px-3 py-1.75 text-sm transition-all ring-offset-background focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px]">
-            <div className="flex flex-wrap gap-1">
-              {selectedChoices.map((choice) => (
-                <Badge key={getChoiceValue(choice)} variant="outline">
-                  {getInputText(choice)}
-                  <button
-                    className="ml-1 rounded-full outline-none ring-offset-background focus:ring-2 focus:ring-ring focus:ring-offset-2"
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") {
+    <>
+      <FormField className={props.className} id={id} name={field.name}>
+        {props.label !== false && (
+          <FormLabel>
+            <FieldTitle
+              label={props.label}
+              source={props.source ?? source}
+              resource={resource}
+              isRequired={isRequired}
+            />
+          </FormLabel>
+        )}
+        <FormControl>
+          <Command
+            onKeyDown={handleKeyDown}
+            shouldFilter={!isFromReference}
+            className="overflow-visible bg-transparent"
+          >
+            <div className="group rounded-md bg-transparent dark:bg-input/30 border border-input px-3 py-1.75 text-sm transition-all ring-offset-background focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px]">
+              <div className="flex flex-wrap gap-1">
+                {selectedChoices.map((choice) => (
+                  <Badge key={getChoiceValue(choice)} variant="outline">
+                    {getInputText(choice)}
+                    <button
+                      className="ml-1 rounded-full outline-none ring-offset-background focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          handleUnselect(choice);
+                        }
+                      }}
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                      }}
+                      onClick={(e) => {
+                        e.preventDefault();
                         handleUnselect(choice);
-                      }
-                    }}
-                    onMouseDown={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                    }}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      handleUnselect(choice);
-                    }}
-                  >
-                    <span className="sr-only">
-                      {translate("ra.action.remove", {
-                        _: "Remove",
-                      })}
-                    </span>
-                    <X className="h-3 w-3" />
-                  </button>
-                </Badge>
-              ))}
-              {/* Avoid having the "Search" Icon by not using CommandInput */}
-              <CommandPrimitive.Input
-                ref={inputRef}
-                value={filterValue}
-                onValueChange={(filter) => {
-                  setFilterValue(filter);
-                  requestAnimationFrame(() => {
-                    listRef.current?.scrollTo(0, 0);
-                  });
-                  // We don't want the ChoicesContext to filter the choices if the input
-                  // is not from a reference as it would also filter out the selected values
-                  if (isFromReference) {
-                    setFilters(filterToQuery(filter), undefined, true);
-                  }
-                }}
-                onBlur={() => setOpen(false)}
-                onFocus={() => setOpen(true)}
-                placeholder={placeholder}
-                className="ml-2 flex-1 bg-transparent outline-none placeholder:text-muted-foreground"
-              />
+                      }}
+                    >
+                      <span className="sr-only">
+                        {translate("ra.action.remove", {
+                          _: "Remove",
+                        })}
+                      </span>
+                      <X className="h-3 w-3" />
+                    </button>
+                  </Badge>
+                ))}
+                {/* Avoid having the "Search" Icon by not using CommandInput */}
+                <CommandPrimitive.Input
+                  ref={inputRef}
+                  value={filterValue}
+                  onValueChange={(filter) => {
+                    setFilterValue(filter);
+                    requestAnimationFrame(() => {
+                      listRef.current?.scrollTo(0, 0);
+                    });
+                    // We don't want the ChoicesContext to filter the choices if the input
+                    // is not from a reference as it would also filter out the selected values
+                    if (isFromReference) {
+                      setFilters(filterToQuery(filter), undefined, true);
+                    }
+                  }}
+                  onBlur={() => setOpen(false)}
+                  onFocus={() => setOpen(true)}
+                  placeholder={placeholder}
+                  className="ml-2 flex-1 bg-transparent outline-none placeholder:text-muted-foreground"
+                />
+              </div>
             </div>
-          </div>
-          <div className="relative">
-            <CommandList ref={listRef}>
-              {open && availableChoices.length > 0 ? (
-                <div className="absolute top-2 z-10 w-full rounded-md border bg-popover text-popover-foreground shadow-md outline-none animate-in">
-                  <CommandGroup className="h-full overflow-auto">
-                    {availableChoices.map((choice) => {
-                      const choiceText = getChoiceText(choice);
-                      return (
-                        <CommandItem
-                          key={getChoiceValue(choice)}
-                          value={getChoiceValue(choice)}
-                          keywords={
-                            React.isValidElement(choiceText)
-                              ? undefined
-                              : [choiceText]
-                          }
-                          onMouseDown={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                          }}
-                          onSelect={() => {
-                            setFilterValue("");
-                            if (isFromReference) {
-                              setFilters(filterToQuery(""));
+            <div className="relative">
+              <CommandList ref={listRef}>
+                {open && finalChoices.length > 0 ? (
+                  <div className="absolute top-2 z-10 w-full rounded-md border bg-popover text-popover-foreground shadow-md outline-none animate-in">
+                    <CommandGroup className="h-full overflow-auto">
+                      {finalChoices.map((choice) => {
+                        const isCreateItem =
+                          !!createItem && choice?.id === createItem.id;
+                        const choiceText = getChoiceText(choice);
+                        return (
+                          <CommandItem
+                            key={getChoiceValue(choice)}
+                            value={
+                              isCreateItem
+                                ? `?${filterValue}?`
+                                : getChoiceValue(choice)
                             }
-                            field.onChange([
-                              ...field.value,
-                              getChoiceValue(choice),
-                            ]);
-                          }}
-                          className="cursor-pointer"
-                        >
-                          {choiceText}
-                        </CommandItem>
-                      );
-                    })}
-                  </CommandGroup>
-                </div>
-              ) : null}
-            </CommandList>
-          </div>
-        </Command>
-      </FormControl>
-      <InputHelperText helperText={props.helperText} />
-      <FormError />
-    </FormField>
+                            keywords={
+                              isCreateItem || React.isValidElement(choiceText)
+                                ? undefined
+                                : [choiceText]
+                            }
+                            disabled={getOptionDisabled(choice)}
+                            onMouseDown={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                            }}
+                            onSelect={() =>
+                              handleChangeWithCreateSupport(choice)
+                            }
+                            className="cursor-pointer"
+                          >
+                            {choiceText}
+                          </CommandItem>
+                        );
+                      })}
+                    </CommandGroup>
+                  </div>
+                ) : null}
+              </CommandList>
+            </div>
+          </Command>
+        </FormControl>
+        <InputHelperText helperText={props.helperText} />
+        <FormError />
+      </FormField>
+      {createElement}
+    </>
   );
 };
 

--- a/src/stories/autocomplete-array-input.stories.tsx
+++ b/src/stories/autocomplete-array-input.stories.tsx
@@ -1,11 +1,26 @@
-import { CoreAdminContext, RecordContextProvider } from "ra-core";
+import {
+  CoreAdminContext,
+  RecordContextProvider,
+  useCreateSuggestionContext,
+  useTranslate,
+} from "ra-core";
 import {
   AutocompleteArrayInput,
   SimpleForm,
   ThemeProvider,
 } from "@/components/admin";
 import { i18nProvider } from "@/lib/i18nProvider";
-import { ReactNode } from "react";
+import { FormEvent, ReactNode, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 
 const record = {
   id: 1,
@@ -56,6 +71,108 @@ export const Basic = ({ theme }: { theme: "system" | "light" | "dark" }) => (
     </SimpleForm>
   </StoryWrapper>
 );
+
+type TagChoice = { id: string; name: string };
+
+const toChoice = (name: string): TagChoice => ({
+  id: name.toLowerCase(),
+  name,
+});
+
+/**
+ * Creation through a function: enough when the new choice only needs the text
+ * users typed in the input.
+ */
+export const OnCreate = () => {
+  const [tagChoices, setTagChoices] = useState(choices);
+  return (
+    <StoryWrapper theme="system">
+      <SimpleForm>
+        <AutocompleteArrayInput
+          source="tags"
+          choices={tagChoices}
+          onCreate={(filter) => {
+            if (!filter) return;
+            const newTag = toChoice(filter);
+            setTagChoices((previous) => [...previous, newTag]);
+            return newTag;
+          }}
+          createLabel="Start typing to create a new tag"
+          createItemLabel="Create %{item}"
+        />
+      </SimpleForm>
+    </StoryWrapper>
+  );
+};
+
+const CreateTag = ({ onSave }: { onSave: (tag: TagChoice) => void }) => {
+  const translate = useTranslate();
+  const { onCancel, onCreate, filter } = useCreateSuggestionContext();
+  const [newTagName, setNewTagName] = useState(filter ?? "");
+
+  const saveTag = () => {
+    const newTag = toChoice(newTagName);
+    onSave(newTag);
+    setNewTagName("");
+    onCreate(newTag);
+  };
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    saveTag();
+  };
+
+  return (
+    <Dialog open onOpenChange={onCancel}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Create a tag</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="name">New tag name</Label>
+            <Input
+              id="name"
+              value={newTagName}
+              onChange={(event) => setNewTagName(event.currentTarget.value)}
+              autoFocus
+            />
+          </div>
+        </form>
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>
+            {translate("ra.action.cancel")}
+          </Button>
+          <Button onClick={saveTag}>{translate("ra.action.save")}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+/**
+ * Creation through an element: required as soon as the new choice needs more
+ * than the text users typed in the input.
+ */
+export const Create = () => {
+  const [tagChoices, setTagChoices] = useState(choices);
+  return (
+    <StoryWrapper theme="system">
+      <SimpleForm>
+        <AutocompleteArrayInput
+          source="tags"
+          choices={tagChoices}
+          create={
+            <CreateTag
+              onSave={(tag) => setTagChoices((previous) => [...previous, tag])}
+            />
+          }
+          createLabel="Start typing to create a new tag"
+          createItemLabel="Create %{item}"
+        />
+      </SimpleForm>
+    </StoryWrapper>
+  );
+};
 
 const getCurrencyChoices = () => {
   const displayNames = new Intl.DisplayNames(

--- a/src/stories/reference-array-input.stories.tsx
+++ b/src/stories/reference-array-input.stories.tsx
@@ -1,8 +1,20 @@
-import { Resource, required, TestMemoryRouter } from "ra-core";
+import {
+  CreateBase,
+  Resource,
+  required,
+  TestMemoryRouter,
+  useCreateSuggestionContext,
+} from "ra-core";
 import polyglotI18nProvider from "ra-i18n-polyglot";
 import englishMessages from "ra-language-english";
 import fakeRestProvider from "ra-data-fakerest";
 
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Admin } from "@/components/admin/admin";
 import { AutocompleteArrayInput } from "@/components/admin/autocomplete-array-input";
 import { Create } from "@/components/admin/create";
@@ -11,6 +23,7 @@ import { ListGuesser } from "@/components/admin/list-guesser";
 import { ShowGuesser } from "@/components/admin/show-guesser";
 import { SimpleForm } from "@/components/admin/simple-form";
 import { ReferenceArrayInput } from "@/components/admin/reference-array-input";
+import { TextInput } from "@/components/admin/text-input";
 
 export default {
   title: "Inputs/ReferenceArrayInput",
@@ -75,6 +88,59 @@ export const WithValidation = () => (
                 source="tags_ids"
               >
                 <AutocompleteArrayInput validate={required()} />
+              </ReferenceArrayInput>
+            </SimpleForm>
+          </Create>
+        }
+        edit={EditGuesser}
+        show={ShowGuesser}
+      />
+    </Admin>
+  </TestMemoryRouter>
+);
+
+const CreateTag = () => {
+  const { onCancel, onCreate, filter } = useCreateSuggestionContext();
+
+  return (
+    <Dialog open onOpenChange={onCancel}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Create a tag</DialogTitle>
+        </DialogHeader>
+        <CreateBase
+          resource="tags"
+          redirect={false}
+          mutationOptions={{ onSuccess: onCreate }}
+        >
+          <SimpleForm defaultValues={{ name: filter }}>
+            <TextInput source="name" autoFocus />
+          </SimpleForm>
+        </CreateBase>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export const WithCreateSupport = () => (
+  <TestMemoryRouter initialEntries={["/posts/create"]}>
+    <Admin dataProvider={dataProvider} i18nProvider={i18nProvider}>
+      <Resource name="tags" recordRepresentation={"name"} />
+      <Resource
+        name="posts"
+        list={ListGuesser}
+        create={
+          <Create resource="posts" record={{ tags_ids: [1, 3] }}>
+            <SimpleForm>
+              <ReferenceArrayInput
+                reference="tags"
+                resource="posts"
+                source="tags_ids"
+              >
+                <AutocompleteArrayInput
+                  create={<CreateTag />}
+                  createItemLabel="Create %{item}"
+                />
               </ReferenceArrayInput>
             </SimpleForm>
           </Create>


### PR DESCRIPTION
Implementing https://github.com/marmelab/atomic-crm/issues/286 (part 1)

## Problem

We cannot create any record from the `AutocompleteArrayInput` record.

## Solution

Add the `create` / `onCreate` (and `createLabel` / `createItemLabel`)

## How To Test

- http://localhost:6006/?path=/story/inputs-autocompletearrayinput--on-create
- http://localhost:6006/?path=/story/inputs-autocompletearrayinput--create

## Additional Checks

- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/shadcn-admin-kit#contributing).