### PR TITLE
Fix the registry install on a fresh project

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,6 +35,25 @@ export default tseslint.config(
         },
       ],
       "no-console": ["error", { allow: ["warn", "error"] }],
+      // Type-only imports must carry the `type` keyword. Without it, projects
+      // built with `verbatimModuleSyntax: true` (what the shadcn templates ship)
+      // keep the import at runtime and crash on a missing export.
+      "@typescript-eslint/consistent-type-imports": [
+        "error",
+        { fixStyle: "inline-type-imports" },
+      ],
+    },
+  },
+  {
+    // The ui components are vendored from shadcn and exempt from the rules
+    // above, but the registry ships them, so they need the type-import rule.
+    extends: [tseslint.configs.base],
+    files: ["src/components/ui/*.tsx"],
+    rules: {
+      "@typescript-eslint/consistent-type-imports": [
+        "error",
+        { fixStyle: "inline-type-imports" },
+      ],
     },
   },
   storybook.configs["flat/recommended"],

--- a/registry.json
+++ b/registry.json
@@ -51,9 +51,13 @@
         "ra-language-english",
         "react-dropzone",
         "react-hook-form",
-        "react-router",
+        "react-router@^7.1.1",
+        "react-router-dom@^7.1.1",
         "tailwind-merge",
         "tw-animate-css"
+      ],
+      "devDependencies": [
+        "@types/lodash"
       ],
       "files": [
         {

--- a/registry.json
+++ b/registry.json
@@ -38,7 +38,7 @@
         "tooltip"
       ],
       "dependencies": [
-        "@tanstack/react-query",
+        "@tanstack/react-query@^5.83.0",
         "class-variance-authority",
         "clsx",
         "diacritic",
@@ -50,14 +50,12 @@
         "ra-i18n-polyglot",
         "ra-language-english",
         "react-dropzone",
-        "react-hook-form",
+        "react-hook-form@^7.65.0",
         "react-router-dom@^7.1.1",
         "tailwind-merge",
         "tw-animate-css"
       ],
-      "devDependencies": [
-        "@types/lodash"
-      ],
+      "devDependencies": ["@types/lodash"],
       "files": [
         {
           "path": "src/components/admin/admin.tsx",

--- a/registry.json
+++ b/registry.json
@@ -51,7 +51,6 @@
         "ra-language-english",
         "react-dropzone",
         "react-hook-form",
-        "react-router@^7.1.1",
         "react-router-dom@^7.1.1",
         "tailwind-merge",
         "tw-animate-css"

--- a/scripts/build_registry.mjs
+++ b/scripts/build_registry.mjs
@@ -26,6 +26,58 @@ const dedupeBy = (items, keySelector) => {
   });
 };
 
+// "react-hook-form@^7.65.0" -> "react-hook-form", "@types/lodash" -> "@types/lodash"
+const packageName = (dep) => {
+  const separator = dep.lastIndexOf("@");
+  return separator > 0 ? dep.slice(0, separator) : dep;
+};
+
+// The ranges declared in registry.json, indexed by package name.
+const declaredRanges = (registry) => {
+  const ranges = new Map();
+
+  for (const item of registry.items) {
+    for (const dep of item.dependencies ?? []) {
+      const name = packageName(dep);
+
+      if (dep !== name) {
+        ranges.set(name, dep);
+      }
+    }
+  }
+
+  return ranges;
+};
+
+// shadcn registry:build appends the dependencies of every registry dependency
+// and derives more from the imports it finds, all without a version range. A
+// built item ends up with both "react-hook-form@^7.65.0" and "react-hook-form",
+// and npm keeps the last spec it sees, so the unversioned one wins and the range
+// we declare is silently dropped. Restore the declared range and keep a single
+// entry per package.
+const pinDependencies = (dependencies, ranges) => {
+  const byName = new Map();
+
+  for (const dep of dependencies) {
+    const name = packageName(dep);
+    const declared = ranges.get(name);
+
+    if (declared) {
+      byName.set(name, declared);
+      continue;
+    }
+
+    const kept = byName.get(name);
+
+    // Prefer whichever spec carries a range over the bare package name.
+    if (kept === undefined || kept === name) {
+      byName.set(name, dep);
+    }
+  }
+
+  return [...byName.values()];
+};
+
 const withFileContents = async (item) => {
   if (!item.files?.length) {
     return item;
@@ -75,6 +127,20 @@ const run = async () => {
     );
 
     await rm(tempDir, { recursive: true, force: true });
+
+    const ranges = declaredRanges(registry);
+
+    for (const item of autoBuiltItems) {
+      const builtPath = path.join(outputDir, `${item.name}.json`);
+      const built = JSON.parse(await readFile(builtPath, "utf8"));
+
+      if (!built.dependencies?.length) {
+        continue;
+      }
+
+      built.dependencies = pinDependencies(built.dependencies, ranges);
+      await writeFile(builtPath, `${JSON.stringify(built, null, 2)}\n`);
+    }
   }
 
   const manualItems = registry.items.filter((item) => manualBuildItems.has(item.name));

--- a/src/components/admin/autocomplete-input.tsx
+++ b/src/components/admin/autocomplete-input.tsx
@@ -39,7 +39,7 @@ import {
   useSupportCreateSuggestion,
 } from "ra-core";
 import { InputHelperText } from "./input-helper-text";
-import { PopoverProps } from "@radix-ui/react-popover";
+import { type PopoverProps } from "@radix-ui/react-popover";
 
 /**
  * Form control that lets users choose a value from a list using a dropdown with autocompletion.

--- a/src/components/admin/boolean-field.tsx
+++ b/src/components/admin/boolean-field.tsx
@@ -1,5 +1,5 @@
 import { Check, type LucideIcon, X } from "lucide-react";
-import { RaRecord, useFieldValue, useTranslate } from "ra-core";
+import { type RaRecord, useFieldValue, useTranslate } from "ra-core";
 
 import type { FieldProps } from "@/lib/field.type.ts";
 import { cn } from "@/lib/utils";

--- a/src/components/admin/bulk-export-button.spec.tsx
+++ b/src/components/admin/bulk-export-button.spec.tsx
@@ -2,13 +2,13 @@ import { describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
 import { BulkExportButton } from "./bulk-export-button";
 import {
-  DataProvider,
+  type DataProvider,
   DataProviderContext,
   ListContextProvider,
   RecordContext,
   ResourceContextProvider,
   useList,
-  UseListOptions,
+  type UseListOptions,
 } from "ra-core";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";

--- a/src/components/admin/form.tsx
+++ b/src/components/admin/form.tsx
@@ -15,7 +15,7 @@ import {
   warning,
 } from "ra-core";
 import { Loader2, Save } from "lucide-react";
-import * as LabelPrimitive from "@radix-ui/react-label";
+import type * as LabelPrimitive from "@radix-ui/react-label";
 import { Slot } from "@radix-ui/react-slot";
 import { FormProvider, useFormContext, useFormState } from "react-hook-form";
 import type { UseMutationOptions } from "@tanstack/react-query";

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -6,7 +6,7 @@ import {
 } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { type Button, buttonVariants } from "@/components/ui/button"
 
 function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
   return (

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { VariantProps, cva } from "class-variance-authority"
+import { type VariantProps, cva } from "class-variance-authority"
 import { PanelLeftIcon } from "lucide-react"
 
 import { useIsMobile } from "@/hooks/use-mobile"

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from "next-themes"
-import { Toaster as Sonner, ToasterProps } from "sonner"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()

--- a/src/demo/authProvider.ts
+++ b/src/demo/authProvider.ts
@@ -1,4 +1,4 @@
-import { AuthProvider, HttpError } from "ra-core";
+import { type AuthProvider, HttpError } from "ra-core";
 import data from "./users.json";
 
 const DEFAULT_IDENTITY = data.users[0];

--- a/src/demo/categories/index.tsx
+++ b/src/demo/categories/index.tsx
@@ -1,4 +1,4 @@
-import { ResourceProps } from "ra-core";
+import { type ResourceProps } from "ra-core";
 import { CategoryList } from "./CategoryList";
 import { CategoryEdit } from "./CategoryEdit";
 import { CategoryCreate } from "./CategoryCreate";

--- a/src/demo/customers/AddressField.tsx
+++ b/src/demo/customers/AddressField.tsx
@@ -1,5 +1,5 @@
 import { useRecordContext } from "ra-core";
-import { Customer } from "../types";
+import { type Customer } from "../types";
 
 export const AddressField = () => {
   const record = useRecordContext<Customer>();

--- a/src/demo/customers/index.ts
+++ b/src/demo/customers/index.ts
@@ -1,4 +1,4 @@
-import { ResourceProps } from "ra-core";
+import { type ResourceProps } from "ra-core";
 import { CustomerList } from "./CustomerList";
 import { CustomerEdit } from "./CustomerEdit";
 import { CustomerCreate } from "./CustomerCreate";

--- a/src/demo/dashboard/Dashboard.tsx
+++ b/src/demo/dashboard/Dashboard.tsx
@@ -11,7 +11,7 @@ import PendingReviews from "./PendingReviews";
 import NewCustomers from "./NewCustomers";
 import OrderChart from "./OrderChart";
 
-import { Order } from "../types";
+import { type Order } from "../types";
 
 interface OrderStats {
   revenue: number;

--- a/src/demo/dashboard/NewCustomers.tsx
+++ b/src/demo/dashboard/NewCustomers.tsx
@@ -6,7 +6,7 @@ import { ListBase, WithListContext, useTranslate } from "ra-core";
 import { subDays } from "date-fns";
 
 import CardWithIcon from "./CardWithIcon";
-import { Customer } from "../types";
+import { type Customer } from "../types";
 
 const NewCustomers = () => {
   const translate = useTranslate();

--- a/src/demo/dashboard/OrderChart.tsx
+++ b/src/demo/dashboard/OrderChart.tsx
@@ -4,7 +4,7 @@ import * as echarts from "echarts";
 import { useTranslate } from "ra-core";
 import { format, subDays, addDays } from "date-fns";
 
-import { Order } from "../types";
+import { type Order } from "../types";
 
 const lastDay = new Date();
 const lastMonthDays = Array.from({ length: 30 }, (_, i) => subDays(lastDay, i));

--- a/src/demo/dashboard/PendingOrder.tsx
+++ b/src/demo/dashboard/PendingOrder.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router";
 import { Avatar, AvatarImage } from "@/components/ui/avatar";
 import { useTranslate, useReference } from "ra-core";
 
-import { Customer, Order } from "../types";
+import { type Customer, type Order } from "../types";
 
 interface Props {
   order: Order;

--- a/src/demo/dashboard/PendingOrders.tsx
+++ b/src/demo/dashboard/PendingOrders.tsx
@@ -1,7 +1,7 @@
 import { useTranslate } from "ra-core";
 import { Card, CardContent } from "@/components/ui/card";
 
-import { Order } from "../types";
+import { type Order } from "../types";
 import { PendingOrder } from "./PendingOrder";
 
 interface Props {

--- a/src/demo/dashboard/PendingReviews.tsx
+++ b/src/demo/dashboard/PendingReviews.tsx
@@ -8,7 +8,7 @@ import { ReferenceField } from "@/components/admin/reference-field";
 
 import CardWithIcon from "./CardWithIcon";
 //import StarRatingField from "../reviews/StarRatingField";
-import { Customer, Review } from "../types";
+import { type Customer, type Review } from "../types";
 
 const PendingReviews = () => {
   const translate = useTranslate();

--- a/src/demo/i18n/en.ts
+++ b/src/demo/i18n/en.ts
@@ -1,4 +1,4 @@
-import { TranslationMessages } from "ra-core";
+import { type TranslationMessages } from "ra-core";
 import englishMessages from "ra-language-english";
 
 const customEnglishMessages: TranslationMessages = {

--- a/src/demo/i18n/fr.ts
+++ b/src/demo/i18n/fr.ts
@@ -1,4 +1,4 @@
-import { TranslationMessages } from "ra-core";
+import { type TranslationMessages } from "ra-core";
 import frenchMessages from "ra-language-french";
 
 const customFrenchMessages: TranslationMessages = {

--- a/src/demo/orders/Basket.tsx
+++ b/src/demo/orders/Basket.tsx
@@ -11,7 +11,7 @@ import { Label } from "@/components/ui/label";
 import { useTranslate, useGetMany, useRecordContext } from "ra-core";
 import { Link } from "react-router";
 
-import { Order, Product } from "../types";
+import { type Order, type Product } from "../types";
 
 export const Basket = () => {
   const record = useRecordContext<Order>();

--- a/src/demo/orders/Totals.tsx
+++ b/src/demo/orders/Totals.tsx
@@ -2,7 +2,7 @@ import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import { Label } from "@/components/ui/label";
 import { useRecordContext, useTranslate } from "ra-core";
 
-import { Order } from "../types";
+import { type Order } from "../types";
 
 export const Totals = () => {
   const record = useRecordContext<Order>();

--- a/src/demo/orders/index.tsx
+++ b/src/demo/orders/index.tsx
@@ -1,4 +1,4 @@
-import { ResourceProps } from "ra-core";
+import { type ResourceProps } from "ra-core";
 import { DollarSign } from "lucide-react";
 import { OrderList } from "./OrderList";
 import { OrderEdit } from "./OrderEdit";

--- a/src/demo/products/index.tsx
+++ b/src/demo/products/index.tsx
@@ -1,4 +1,4 @@
-import { ResourceProps } from "ra-core";
+import { type ResourceProps } from "ra-core";
 import { ProductList } from "./ProductList";
 import { ProductEdit } from "./ProductEdit";
 import { ProductCreate } from "./ProductCreate";

--- a/src/demo/types.ts
+++ b/src/demo/types.ts
@@ -1,4 +1,4 @@
-import * as DataGenerator from "data-generator-retail";
+import type * as DataGenerator from "data-generator-retail";
 
 export type ThemeName = "light" | "dark";
 

--- a/src/stories/array-input.stories.tsx
+++ b/src/stories/array-input.stories.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { type ReactNode } from "react";
 import {
   CoreAdminContext,
   minLength,

--- a/src/stories/autocomplete-array-input.stories.tsx
+++ b/src/stories/autocomplete-array-input.stories.tsx
@@ -10,7 +10,7 @@ import {
   ThemeProvider,
 } from "@/components/admin";
 import { i18nProvider } from "@/lib/i18nProvider";
-import { FormEvent, ReactNode, useState } from "react";
+import { type FormEvent, type ReactNode, useState } from "react";
 import {
   Dialog,
   DialogContent,

--- a/src/stories/columns-button.stories.tsx
+++ b/src/stories/columns-button.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { DataProvider, memoryStore, Resource, TestMemoryRouter } from "ra-core";
+import { type DataProvider, memoryStore, Resource, TestMemoryRouter } from "ra-core";
 import { i18nProvider } from "@/lib/i18nProvider.ts";
 import {
   Admin,

--- a/src/stories/data-table.stories.tsx
+++ b/src/stories/data-table.stories.tsx
@@ -1,5 +1,5 @@
 import {
-  DataProvider,
+  type DataProvider,
   memoryStore,
   Resource,
   TestMemoryRouter,

--- a/src/stories/date-input.stories.tsx
+++ b/src/stories/date-input.stories.tsx
@@ -13,9 +13,9 @@ import get from "lodash/get";
 import {
   Create,
   SimpleForm,
-  SimpleFormProps,
+  type SimpleFormProps,
   DateInput,
-  DateInputProps,
+  type DateInputProps,
 } from "@/components/admin";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";

--- a/src/stories/date-time-input.stories.tsx
+++ b/src/stories/date-time-input.stories.tsx
@@ -18,9 +18,9 @@ import {
   Create,
   Edit,
   SimpleForm,
-  SimpleFormProps,
+  type SimpleFormProps,
   DateTimeInput,
-  DateTimeInputProps,
+  type DateTimeInputProps,
 } from "@/components/admin";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";

--- a/src/stories/error.stories.tsx
+++ b/src/stories/error.stories.tsx
@@ -1,7 +1,7 @@
 import { CoreAdminContext } from "ra-core";
 import { ThemeProvider } from "@/components/admin";
 import { i18nProvider } from "@/lib/i18nProvider";
-import { ReactNode } from "react";
+import { type ReactNode } from "react";
 import { Error as RaError } from "@/components/admin/error";
 
 export default {

--- a/src/stories/export-button.stories.tsx
+++ b/src/stories/export-button.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { DataProvider, memoryStore, Resource, TestMemoryRouter } from "ra-core";
+import { type DataProvider, memoryStore, Resource, TestMemoryRouter } from "ra-core";
 import polyglotI18nProvider from "ra-i18n-polyglot";
 import defaultMessages from "ra-language-english";
 import {

--- a/src/stories/filter-button.stories.tsx
+++ b/src/stories/filter-button.stories.tsx
@@ -1,11 +1,11 @@
-import { DataProvider, memoryStore, Resource, TestMemoryRouter } from "ra-core";
+import { type DataProvider, memoryStore, Resource, TestMemoryRouter } from "ra-core";
 import { i18nProvider } from "@/lib/i18nProvider.ts";
 import {
   Admin,
   DataTable,
   FilterButton,
   List,
-  ListProps,
+  type ListProps,
   NumberInput,
   SearchInput,
   SelectInput,

--- a/src/stories/guesser-empty.stories.tsx
+++ b/src/stories/guesser-empty.stories.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { type ReactNode } from "react";
 import polyglotI18nProvider from "ra-i18n-polyglot";
 import { I18nContextProvider } from "ra-core";
 import { GuesserEmpty } from "@/components/admin/guesser-empty";

--- a/src/stories/loading.stories.tsx
+++ b/src/stories/loading.stories.tsx
@@ -2,7 +2,7 @@ import polyglotI18nProvider from "ra-i18n-polyglot";
 import englishMessages from "ra-language-english";
 import { I18nContextProvider } from "ra-core";
 import { Loading } from "@/components/admin/loading";
-import { ReactNode } from "react";
+import { type ReactNode } from "react";
 import { ThemeProvider } from "@/components/admin";
 
 export default {

--- a/src/stories/rich-text-input.stories.tsx
+++ b/src/stories/rich-text-input.stories.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useRef } from "react";
+import { type ReactNode, useRef } from "react";
 import type { Editor } from "@tiptap/react";
 import { CoreAdminContext, RecordContextProvider, required } from "ra-core";
 import { useFormContext, useWatch } from "react-hook-form";

--- a/src/stories/sort-button.stories.tsx
+++ b/src/stories/sort-button.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { DataProvider, memoryStore, Resource, TestMemoryRouter } from "ra-core";
+import { type DataProvider, memoryStore, Resource, TestMemoryRouter } from "ra-core";
 import defaultMessages from "ra-language-english";
 import polyglotI18nProvider from "ra-i18n-polyglot";
 import { i18nProvider } from "@/lib/i18nProvider.ts";

--- a/src/stories/text-array-input.stories.tsx
+++ b/src/stories/text-array-input.stories.tsx
@@ -1,7 +1,7 @@
 import { CoreAdminContext, RecordContextProvider, required } from "ra-core";
 import { TextArrayInput, SimpleForm, ThemeProvider } from "@/components/admin";
 import { i18nProvider } from "@/lib/i18nProvider";
-import { ReactNode } from "react";
+import { type ReactNode } from "react";
 
 const record = {
   id: 1,

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -11,6 +11,9 @@
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
+    /* Matches the shadcn templates, so type-only imports that would survive
+       into the registry output and crash at runtime fail the typecheck here. */
+    "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Problem

Installing the registry into a fresh shadcn project was broken twice over:

- Dependencies were declared without version ranges. npm resolved `react-router` to 8.x, outside ra-core's peer range, and looped on ERESOLVE. `react-router-dom` was missing entirely although ra-core's dist imports it, which crashed the dev server.
- Three shipped files imported a type without the `type` keyword. The shadcn templates ship `verbatimModuleSyntax: true`, so the browser threw `does not provide an export named VariantProps`, then `PopoverProps`, then `RaRecord`.

## Solution

- Declare `react-router-dom@^7.1.1`, which carries `react-router` as a regular dependency. Declaring `react-router` explicitly instead breaks the react-router framework template, which pins an exact version.
- Pin the other two ra-core peers, `react-hook-form@^7.65.0` and `@tanstack/react-query@^5.83.0`. They install correctly today only because the current latest still falls inside ra-core's ranges.
- Restore those ranges in `build_registry.mjs`. `shadcn registry:build` re-appends the same packages unversioned, and npm keeps the last spec it sees, so the ranges were silently dropped from the built output.
- Declare `@types/lodash`.
- Enforce type-only imports with `@typescript-eslint/consistent-type-imports`, including on the vendored `components/ui` files, and turn on `verbatimModuleSyntax` so the typecheck reproduces what the templates do.

## How to test

`shadcn init --template vite --base radix --name my-app`, then add the registry: completes in about 40 seconds with no npm workaround and boots to the welcome screen with a clean console.

`make typecheck`, `make lint` and `make test` pass.