### PR TITLE
Forward routerProvider from Admin to CoreAdminContext

### DIFF
--- a/src/components/admin/admin.tsx
+++ b/src/components/admin/admin.tsx
@@ -119,6 +119,7 @@ export const Admin = (props: CoreAdminProps) => {
     queryClient,
     ready = Ready,
     requireAuth,
+    routerProvider,
     store = defaultStore,
     title = "Shadcn Admin",
   } = props;
@@ -129,6 +130,7 @@ export const Admin = (props: CoreAdminProps) => {
       dataProvider={dataProvider}
       i18nProvider={i18nProvider}
       queryClient={queryClient}
+      routerProvider={routerProvider}
       store={store}
     >
       <AdminUI


### PR DESCRIPTION
## Problem

`Admin` forwards a fixed list of props to `CoreAdminContext`, and `routerProvider` was missing from it. `<Admin routerProvider={tanStackRouterProvider}>` was silently ignored and ra-core fell back to its react-router default, so TanStack Start apps crashed during SSR with `document is not defined` and the docs documented a no-op.

## Solution

Add `routerProvider` to the destructure and forward it.

## How to test

Scaffold a TanStack Start project, render `<Admin routerProvider={tanStackRouterProvider}>` as [Installation](https://marmelab.com/shadcn-admin-kit/Install/) describes, and check it boots instead of crashing with `document is not defined`.